### PR TITLE
Enable sphinx viewcode extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
 ]
 


### PR DESCRIPTION
Hi,

This PR is a one line change that enables the user to jump to the source code in the API reference documentation.

![image](https://user-images.githubusercontent.com/47760695/213123390-f30a3d40-fb66-43bc-ac62-0ab3c6062313.png)


![image](https://user-images.githubusercontent.com/47760695/213123315-335b58e9-6698-4070-91b7-eed118915e6e.png)


