### PR TITLE
Modern Sphinx Immaterial Theme for Documentation Website

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ django.setup()
 # -- Project information -----------------------------------------------------
 
 project = 'PolicyKit'
-copyright = '2021, PolicyKit'
+copyright = '2023, PolicyKit'
 author = 'PolicyKit'
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
 ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
+    "sphinx_immaterial",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -57,7 +58,7 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+html_theme = "sphinx_immaterial"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/policykit/requirements.txt
+++ b/policykit/requirements.txt
@@ -1,4 +1,4 @@
-alabaster==0.7.12
+sphinx-immaterial==0.11.2
 amqp==2.5.2
 appdirs==1.4.4
 appnope==0.1.0


### PR DESCRIPTION
Hi,

This PR adds the modern [sphinx-immaterial](https://github.com/jbms/sphinx-immaterial) theme for the docs.

It also enables the [viewcode](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html) plugin for jumping to the source code and updates the copyright year.

Below are some screenshots:

![image](https://user-images.githubusercontent.com/47760695/213126002-3b3a892b-af91-41df-a222-2dd6ad460574.png)

![image](https://user-images.githubusercontent.com/47760695/213126055-e8002390-87cd-4e30-9715-efb88279b08d.png)

![image](https://user-images.githubusercontent.com/47760695/213126131-2cc55c38-553e-4427-8d5e-1565dd9b29ba.png)

### Nice Search Bar

![image](https://user-images.githubusercontent.com/47760695/213126302-38edc351-1192-4030-8d67-11d2cf1027b9.png)
