### PR TITLE
Collective voice tweaks

### DIFF
--- a/policykit/integrations/slack/models.py
+++ b/policykit/integrations/slack/models.py
@@ -155,9 +155,12 @@ class SlackCommunity(CommunityPlatform):
             raise Exception("must provide method_name in values to slack make_call")
         return self.metagov_plugin.method(**values)
     
-    def get_conversations(self, types=["channel"]):
+    def get_conversations(self, types=["channel"], types_arg="public_channel"):
         """
             acceptable types are "im", "group", "channel"
+
+            types_arg is the exact `types` arg that's passed to list.conversations
+                Allows for asking for private_channel only
         """
         def get_channel_type(channel):
             if channel.get("is_im", False):
@@ -169,9 +172,7 @@ class SlackCommunity(CommunityPlatform):
             else:
                 return None
         
-        # logger.debug("start getting conversations")
-        response = self.__make_generic_api_call("conversations.list", {})
-        #logger.debug("get_conversations response: " + str(response))
+        response = self.__make_generic_api_call("conversations.list", {"types": types_arg})
         return [channel for channel in response["channels"] if get_channel_type(channel) in types]
     
     def get_real_users(self):
@@ -180,7 +181,7 @@ class SlackCommunity(CommunityPlatform):
         """
         response = self.__make_generic_api_call("users.list", {})
         members = response['members']
-        ret = [{'value': x['id'], 'name': x['real_name']} for x in members if x['is_bot'] is False and x['name'] != 'slackbot']
+        ret = [{'value': x['id'], 'name': x.get('real_name', '')} for x in members if x['is_bot'] is False and x['name'] != 'slackbot']
         return ret
 
 

--- a/policykit/integrations/slack/models.py
+++ b/policykit/integrations/slack/models.py
@@ -244,7 +244,7 @@ class SlackPostMessage(GovernableAction):
         message = kwargs.get("message", None)
         channel = kwargs.get("channel", None)
         thread =  kwargs.get("thread", None)
-        return f"slack.post_message(text={message} channel={channel}, thread_ts={thread}"
+        return f"slack.post_message(text={message}, channel={channel}, thread_ts={thread})"
 
 
 class SlackRenameConversation(GovernableAction):

--- a/policykit/policyengine/utils.py
+++ b/policykit/policyengine/utils.py
@@ -346,7 +346,7 @@ def load_entities(platform, get_slack_users=False):
                             {
                                 "name": channel.get("name", channel["id"]), 
                                 "value": channel["id"]
-                            } for channel in platform.get_conversations(types=["channel"])
+                            } for channel in platform.get_conversations(types=["channel"], types_arg="private_channel")
                         ]
     if get_slack_users:
         entities["SlackUser"] = platform.get_real_users()

--- a/policykit/policytemplates/procedures.json
+++ b/policykit/policytemplates/procedures.json
@@ -11,7 +11,7 @@
         "notify": [
             {
                 "action": "initiate_vote",
-                "vote_message": "An expense was submitted to Open Collective and requires a vote. Expense description: {action.description} | Amount: {action.formatted_amount} {action.currency} | Tags: {action.tags} | Payee (OC username): {action.expense_user_slug} |             Eligible voters please react with :thumbsup: or :thumbsdown: on this post to vote. See the expense on OpenCollective: {action.url}",
+                "vote_message": "An expense was submitted to Open Collective and requires a vote. Description: {action.description} | Amount: {action.formatted_amount} {action.currency} | Tags: {action.tags} | Username of payee: {action.expense_user_slug} | Eligible voters please react with :thumbsup: or :thumbsdown: on this post to vote. {action.url} to see the expense on OpenCollective.",
                 "post_type": "channel",
                 "users": "variables.users",
                 "channel": "variables.vote_channel",
@@ -19,13 +19,13 @@
             },
             {
                 "action": "slackpostmessage",
-                "text": "Based on our CollectiveVoice policy named {policy.name} (Peer Approval), this expense requires one eligible voter to give a thumbs up for approval.",
+                "message": "Based on our CollectiveVoice policy named {policy.name} (Peer Approval), this expense requires one eligible voter to give a thumbs up for approval.",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             },
             {
                 "action": "slackpostmessage",
-                "text": "variables.vote_message",
+                "message": "variables.vote_message",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             }
@@ -38,7 +38,7 @@
             },
             {
                 "action": "slackpostmessage",
-                "text": "Vote passed, Expense was approved!",
+                "message": "Vote passed, Expense was approved!",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             }
@@ -51,7 +51,7 @@
             },
             {
                 "action": "slackpostmessage",
-                "text": "Vote failed, Expense was not approved!",
+                "message": "Vote failed, Expense was not approved!",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             }
@@ -121,7 +121,7 @@
         "notify": [
             {
                 "action": "initiate_vote",
-                "vote_message": "An expense was submitted to Open Collective and requires a vote. Expense description: {action.description} | Amount: {action.formatted_amount} {action.currency} | Tags: {action.tags} | Payee (OC username): {action.expense_user_slug} |             Eligible voters please react with :thumbsup: or :thumbsdown: on this post to vote. See the expense on OpenCollective: {action.url}",
+                "vote_message": "An expense was submitted to Open Collective and requires a vote. Description: {action.description} | Amount: {action.formatted_amount} {action.currency} | Tags: {action.tags} | Username of payee: {action.expense_user_slug} | Eligible voters please react with :thumbsup: or :thumbsdown: on this post to vote. {action.url} to see the expense on OpenCollective.",
                 "post_type": "channel",
                 "users": "variables.users",
                 "channel": "variables.vote_channel",
@@ -129,13 +129,13 @@
             },
             {
                 "action": "slackpostmessage",
-                "text": "Based on our CollectiveVoice policy named {policy.name} (Majority Vote), this expense requires a majority of eligible voters to give a thumbs up for approval.",
+                "message": "Based on our CollectiveVoice policy named {policy.name} (Majority Vote), this expense requires a majority of eligible voters to give a thumbs up for approval.",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             },
             {
                 "action": "slackpostmessage",
-                "text": "variables.vote_message",
+                "message": "variables.vote_message",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             }
@@ -148,7 +148,7 @@
             },
             {
                 "action": "slackpostmessage",
-                "text": "Vote passed, Expense was approved!",
+                "message": "Vote passed, Expense was approved!",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             }
@@ -161,7 +161,7 @@
             },
             {
                 "action": "slackpostmessage",
-                "text": "Vote failed, Expense was not approved!",
+                "message": "Vote failed, Expense was not approved!",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             }
@@ -231,7 +231,7 @@
         "notify": [
             {
                 "action": "initiate_vote",
-                "vote_message": "An expense was submitted to Open Collective and requires a vote. Expense description: {action.description} | Amount: {action.formatted_amount} {action.currency} | Tags: {action.tags} | Payee (OC username): {action.expense_user_slug} |             Eligible voters please react with :thumbsup: or :thumbsdown: on this post to vote. See the expense on OpenCollective: {action.url}",
+                "vote_message": "An expense was submitted to Open Collective and requires a vote. Description: {action.description} | Amount: {action.formatted_amount} {action.currency} | Tags: {action.tags} | Username of payee: {action.expense_user_slug} | Eligible voters please react with :thumbsup: or :thumbsdown: on this post to vote. {action.url} to see the expense on OpenCollective.",
                 "post_type": "channel",
                 "users": "variables.users",
                 "channel": "variables.vote_channel",
@@ -239,13 +239,13 @@
             },
             {
                 "action": "slackpostmessage",
-                "text": "Based on our CollectiveVoice policy named {policy.name} (Consensus), this expense all eligible voters to give a thumbs up for approval.",
+                "message": "Based on our CollectiveVoice policy named {policy.name} (Consensus), this expense all eligible voters to give a thumbs up for approval.",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             },
             {
                 "action": "slackpostmessage",
-                "text": "variables.vote_message",
+                "message": "variables.vote_message",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             }
@@ -258,7 +258,7 @@
             },
             {
                 "action": "slackpostmessage",
-                "text": "Vote passed, Expense was approved!",
+                "message": "Vote passed, Expense was approved!",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             }
@@ -271,7 +271,7 @@
             },
             {
                 "action": "slackpostmessage",
-                "text": "Vote failed, Expense was not approved!",
+                "message": "Vote failed, Expense was not approved!",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             }
@@ -341,7 +341,7 @@
         "notify": [
             {
                 "action": "initiate_vote",
-                "vote_message": "An expense was submitted to Open Collective and requires a vote. Expense description: {action.description} | Amount: {action.formatted_amount} {action.currency} | Tags: {action.tags} | Payee (OC username): {action.expense_user_slug} |             Eligible voters please react with :thumbsup: or :thumbsdown: on this post to vote. See the expense on OpenCollective: {action.url}",
+                "vote_message": "An expense was submitted to Open Collective and requires a vote. Description: {action.description} | Amount: {action.formatted_amount} {action.currency} | Tags: {action.tags} | Username of payee: {action.expense_user_slug} | Eligible voters please react with :thumbsup: or :thumbsdown: on this post to vote. {action.url} to see the expense on OpenCollective.",
                 "post_type": "channel",
                 "users": "variables.users",
                 "channel": "variables.vote_channel",
@@ -349,13 +349,13 @@
             },
             {
                 "action": "slackpostmessage",
-                "text": "This vote will be based on {policy.name} (Custom Voting)",
+                "message": "This vote will be based on {policy.name} (Custom Voting)",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             },
             {
                 "action": "slackpostmessage",
-                "text": "variables.vote_message",
+                "message": "variables.vote_message",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             }
@@ -368,7 +368,7 @@
             },
             {
                 "action": "slackpostmessage",
-                "text": "Vote passed, Expense was approved!",
+                "message": "Vote passed, Expense was approved!",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             }
@@ -381,7 +381,7 @@
             },
             {
                 "action": "slackpostmessage",
-                "text": "Vote failed, Expense was not approved!",
+                "message": "Vote failed, Expense was not approved!",
                 "channel": "variables.vote_channel",
                 "thread": "proposal.vote_post_id"
             }

--- a/policykit/templates/collectivevoice/edit_expenses.html
+++ b/policykit/templates/collectivevoice/edit_expenses.html
@@ -85,7 +85,7 @@
     const filter_parameters_dict = JSON.parse('{{filter_parameters | safe}}');
     const filters_per_app = JSON.parse('{{filter_modules | safe}}');
     console.log(filters_per_app)
-    const entities = JSON.parse('{{entities|safe}}');
+    const entities = JSON.parse('{{entities|safe|addslashes}}');
     const showFilterParameters = () => {
         var selected_options = Array.from(document.getElementById("actionpicker").selectedOptions);
         selected_options = selected_options.filter(option => option.value != "none");

--- a/policykit/templates/collectivevoice/edit_voting.html
+++ b/policykit/templates/collectivevoice/edit_voting.html
@@ -80,7 +80,7 @@
 <script>
     const procedure_details = JSON.parse('{{procedure_details|safe}}');
     const procedures = JSON.parse('{{procedures|safe}}');
-    const entities = JSON.parse('{{entities|safe}}');
+    const entities = JSON.parse('{{entities|safe|addslashes}}');
 
     const showProcedureDetails = () => {
         var cur_index = parseInt(document.getElementById("procedure-picker").value);

--- a/policykit/templates/collectivevoice/home.html
+++ b/policykit/templates/collectivevoice/home.html
@@ -62,14 +62,14 @@
   </button>
   </div> -->
 
-  <div>
+  <!-- <div>
     Preview:
     </div>
     <div>
     <img style="width:300px" src="{% static 'policyengine/img/collectivevoice_preview.png' %}"
       alt="Image showing what the vote will look like in Slack">
 
-  </div>
+  </div> -->
 
   <br>
   <div>


### PR DESCRIPTION
Opening up a PR with a collection of very small bug fixes and tweaks that relate to rolling out the CollectiveVoice policy building app.

- fixing a typo with slack.post_message action
- removing the preview image from the collective voice UI so we can select a more standardized way of updating it and sending to /static
- fix an issue when names have quote characters
- update procedures.json because the "text" field was renamed to "message"
- add an option to get private channels only for the Collective Voice "pick channel UI"