### PR TITLE
Adding "disable without deletion" flow for OC plugin

### DIFF
--- a/policykit/integrations/opencollective/urls.py
+++ b/policykit/integrations/opencollective/urls.py
@@ -5,4 +5,5 @@ from integrations.opencollective import views
 
 urlpatterns = [
     path('install', views.opencollective_install),
+    path('disable_integration_without_deletion', views.disable_integration_without_deletion),
 ]

--- a/policykit/templates/policyadmin/dashboard/settings.html
+++ b/policykit/templates/policyadmin/dashboard/settings.html
@@ -118,6 +118,10 @@
       {% endif %}
 
       <a href="/{{name}}/disable_integration?id={{data.id}}" class="btn btn-sm btn-outline-danger">Delete Integration</a>
+      {% if name == "opencollective" %}
+      <a href="/{{name}}/disable_integration_without_deletion?id={{data.id}}" class="btn btn-sm btn-outline-danger">Disable Integration</a>
+      {{data}}
+      {% endif %}
     </div>
   </div>
   {% empty %}


### PR DESCRIPTION
Special endpoint so we can easily re-run OC OAuth flow to get a fresh token.

Currently appears an additional "Disable" button, next to the "Delete" button under the OpenCollective section of the settings page. After clicking disable, user can re-add OC flow and pending proposals will not be deleted.