### PR TITLE
#620  Support adding or removing a role from a list of users in the backend

### DIFF
--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -775,12 +775,16 @@ def role_action_users(request):
         action = PolicykitRemoveUserRole()
     else:
         return HttpResponseBadRequest()
-
+    
+    if not isinstance(data['user'], list):
+        usernames = [data['user']]
+    else:
+        usernames = data['user']
     action.community = user.constitution_community
     action.initiator = user
     action.role = CommunityRole.objects.filter(name=data['role'])[0]
     action.save(evaluate_action=False)
-    action.users.set(CommunityUser.objects.filter(username=data['user']))
+    action.users.set(CommunityUser.objects.filter(username__in=usernames))
     action.save(evaluate_action=True)
 
     return HttpResponse()


### PR DESCRIPTION
In the old policykit page, the frontend adds or removes a role from a user through the endpoint `role_action_users`. Therefore, I improved the implementation of the function policyengine/views.role_action_users. It now can accept user either as a string or a list of strings. 