### PR TITLE
Upgrade python dependencies to handle cython 3.0.0

### DIFF
--- a/policykit/requirements.txt
+++ b/policykit/requirements.txt
@@ -29,8 +29,8 @@ django-tables2==2.3.4
 django-timezone-field==4.1.2
 djangorestframework==3.12.4
 docutils==0.16
-gevent==20.6.2
-greenlet==0.4.17
+gevent==24.2.1
+greenlet==3.0.3
 idna==2.9
 imagesize==1.2.0
 importlib-metadata==1.4.0
@@ -54,7 +54,7 @@ pathspec==0.8.1
 pexpect==4.7.0
 pickleshare==0.7.5
 prompt-toolkit==3.0.2
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.9
 ptyprocess==0.6.0
 pycodestyle==2.7.0
 pycryptodome==3.10.1
@@ -68,8 +68,8 @@ python-crontab==2.4.0
 python-dateutil==2.8.1
 pytz==2019.3
 regex==2021.3.17
-requests==2.23.0
-RestrictedPython==5.2
+requests==2.31.0
+RestrictedPython==7.0
 six==1.15.0
 snowballstemmer==2.1.0
 Sphinx==3.5.4
@@ -83,7 +83,7 @@ sphinxcontrib-serializinghtml==1.1.4
 sqlparse==0.3.0
 toml==0.10.2
 traitlets==4.3.3
-typed-ast==1.4.2
+typed-ast==1.5.5
 typing-extensions==3.7.4.3
 urllib3==1.25.8
 vine==1.3.0


### PR DESCRIPTION
I was unable to run `pip install -r policykit/requirements.txt` on a fresh Linux or MacOS system. The dependencies hadn't been updated since [Cython 3.0.0 was released and broke a bunch of stuff](https://devclass.com/2023/07/19/cython-3-0-released-after-nearly-5-years-but-beware-breaking-changes/)

I was able to run `pip install -r requirements.txt` after the changes in this PR. 

A few tests fail for me, but I'm not convinced they would pass before the upgrade and I can't see any CI here to check against. If whoever is reviewing this has a working install, please confirm the test fail for them too. 

I've pasted the test failures I'm getting below. If they are expected to fail, I can raise another PR that skips them. 

```
======================================================================
ERROR: test_copy_policy_as_template (tests.test_clone_policy.ClonePolicyTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/daniel/src/policykit/policykit/tests/test_clone_policy.py", line 18, in setUp
    self.policy_source = Policy.objects.create(**TestUtils.ALL_ACTIONS_PASS, kind=Policy.TRIGGER, community=self.community_source, is_template=True)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/query.py", line 451, in create
    obj = self.model(**kwargs)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/base.py", line 503, in __init__
    raise TypeError("%s() got an unexpected keyword argument '%s'" % (cls.__name__, kwarg))
TypeError: Policy() got an unexpected keyword argument 'is_template'

======================================================================
ERROR: test_copy_policy_to_community (tests.test_clone_policy.ClonePolicyTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/daniel/src/policykit/policykit/tests/test_clone_policy.py", line 18, in setUp
    self.policy_source = Policy.objects.create(**TestUtils.ALL_ACTIONS_PASS, kind=Policy.TRIGGER, community=self.community_source, is_template=True)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/query.py", line 451, in create
    obj = self.model(**kwargs)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/base.py", line 503, in __init__
    raise TypeError("%s() got an unexpected keyword argument '%s'" % (cls.__name__, kwarg))
TypeError: Policy() got an unexpected keyword argument 'is_template'

======================================================================
ERROR: test_copy_policy_with_variable_data (tests.test_clone_policy.ClonePolicyTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/daniel/src/policykit/policykit/tests/test_clone_policy.py", line 18, in setUp
    self.policy_source = Policy.objects.create(**TestUtils.ALL_ACTIONS_PASS, kind=Policy.TRIGGER, community=self.community_source, is_template=True)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/query.py", line 451, in create
    obj = self.model(**kwargs)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/base.py", line 503, in __init__
    raise TypeError("%s() got an unexpected keyword argument '%s'" % (cls.__name__, kwarg))
TypeError: Policy() got an unexpected keyword argument 'is_template'

======================================================================
ERROR: test_no_community_raises_exception (tests.test_clone_policy.ClonePolicyTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/daniel/src/policykit/policykit/tests/test_clone_policy.py", line 18, in setUp
    self.policy_source = Policy.objects.create(**TestUtils.ALL_ACTIONS_PASS, kind=Policy.TRIGGER, community=self.community_source, is_template=True)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/query.py", line 451, in create
    obj = self.model(**kwargs)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/base.py", line 503, in __init__
    raise TypeError("%s() got an unexpected keyword argument '%s'" % (cls.__name__, kwarg))
TypeError: Policy() got an unexpected keyword argument 'is_template'

======================================================================
ERROR: test_not_template_policy_raises_exception (tests.test_clone_policy.ClonePolicyTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/daniel/src/policykit/policykit/tests/test_clone_policy.py", line 18, in setUp
    self.policy_source = Policy.objects.create(**TestUtils.ALL_ACTIONS_PASS, kind=Policy.TRIGGER, community=self.community_source, is_template=True)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/query.py", line 451, in create
    obj = self.model(**kwargs)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/base.py", line 503, in __init__
    raise TypeError("%s() got an unexpected keyword argument '%s'" % (cls.__name__, kwarg))
TypeError: Policy() got an unexpected keyword argument 'is_template'

======================================================================
ERROR: test_saving_template_policy_without_community (tests.test_policy_community_required.PolicyCommunityTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/daniel/src/policykit/policykit/tests/test_policy_community_required.py", line 22, in test_saving_template_policy_without_community
    policy = Policy.objects.create(
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/query.py", line 451, in create
    obj = self.model(**kwargs)
  File "/Users/daniel/.venvs/policykit_venv38/lib/python3.8/site-packages/django/db/models/base.py", line 503, in __init__
    raise TypeError("%s() got an unexpected keyword argument '%s'" % (cls.__name__, kwarg))
TypeError: Policy() got an unexpected keyword argument 'is_template'

======================================================================
FAIL: test_saving_policy_without_community_raises_exception (tests.test_policy_community_required.PolicyCommunityTests)
----------------------------------------------------------------------
TypeError: Policy() got an unexpected keyword argument 'is_template'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/daniel/src/policykit/policykit/tests/test_policy_community_required.py", line 14, in test_saving_policy_without_community_raises_exception
    Policy.objects.create(
AssertionError: "Non template policies must have a community" does not match "Policy() got an unexpected keyword argument 'is_template'"
```