### PR TITLE
implement the /api/members endpoint

### DIFF
--- a/policykit/policyengine/api_views.py
+++ b/policykit/policyengine/api_views.py
@@ -1,0 +1,59 @@
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.exceptions import NotFound 
+from django.contrib.auth import get_user
+from django.db import transaction
+from policyengine.serializers import MemberSummarySerializer, PutMembersRequestSerializer
+
+@api_view(['GET', 'PUT'])
+@permission_classes([IsAuthenticated])
+@transaction.atomic
+def members(request):
+    user = get_user(request)
+
+    if request.method == 'GET':
+        members = get_members(user)
+        return Response(
+            MemberSummarySerializer(members, many=True).data
+        )
+
+    if request.method == 'PUT':
+        req = PutMembersRequestSerializer(data=request.data)
+        req.is_valid(raise_exception=True)
+        put_members(user, **req.validated_data)
+        return Response({}, status=200)
+
+    raise NotImplemented
+
+def get_members(user):
+    from policyengine.models import CommunityUser
+    members = CommunityUser.objects.filter(community__community=user.community.community)
+    return members
+
+def put_members(user, action, role, members):
+    from constitution.models import (PolicykitAddUserRole,
+                                     PolicykitRemoveUserRole)
+
+    from policyengine.models import CommunityRole, CommunityUser
+
+    action_model = None
+    if action == 'assign':
+        action_model = PolicykitAddUserRole()
+    elif action == 'revoke':
+        action_model = PolicykitRemoveUserRole()
+    else:
+        raise ValueError('Invalid action')
+
+    action_model.community = user.constitution_community
+    action_model.initiator = user
+    try:
+        action_model.role = CommunityRole.objects.filter(pk=role, community=user.community.community)[0]
+    except IndexError:
+        raise NotFound('Role not found')
+
+    action_model.save(evaluate_action=False)
+    action_model.users.set(CommunityUser.objects.filter(id__in=members, community__community=user.community.community))
+    if len(action_model.users.all()) != len(members):
+        raise NotFound('User not found')
+    action_model.save(evaluate_action=True)

--- a/policykit/policyengine/api_views.py
+++ b/policykit/policyengine/api_views.py
@@ -38,9 +38,9 @@ def put_members(user, action, role, members):
     from policyengine.models import CommunityRole, CommunityUser
 
     action_model = None
-    if action == 'assign':
+    if action == 'Add':
         action_model = PolicykitAddUserRole()
-    elif action == 'revoke':
+    elif action == 'Remove':
         action_model = PolicykitRemoveUserRole()
     else:
         raise ValueError('Invalid action')

--- a/policykit/policyengine/serializers.py
+++ b/policykit/policyengine/serializers.py
@@ -1,0 +1,21 @@
+import rest_framework.serializers as serializers
+from rest_framework.exceptions import ValidationError
+
+class CommunityRoleSummarySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField(source='__str__')
+
+class MemberSummarySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField(source='__str__')
+    avatar = serializers.CharField()
+    roles = CommunityRoleSummarySerializer(many=True, source='get_roles')
+
+def validate_action_field(value):
+    if value not in ['assign', 'revoke']:
+        raise ValidationError("Action must be 'assign' or 'revoke'")
+
+class PutMembersRequestSerializer(serializers.Serializer):
+    action = serializers.CharField(validators=[validate_action_field])
+    role = serializers.IntegerField()  # pk of role to assign
+    members = serializers.ListField(child=serializers.IntegerField())  # list of user pks to assign to role

--- a/policykit/policyengine/serializers.py
+++ b/policykit/policyengine/serializers.py
@@ -12,8 +12,8 @@ class MemberSummarySerializer(serializers.Serializer):
     roles = CommunityRoleSummarySerializer(many=True, source='get_roles')
 
 def validate_action_field(value):
-    if value not in ['assign', 'revoke']:
-        raise ValidationError("Action must be 'assign' or 'revoke'")
+    if value not in ['Add', 'Remove']:
+        raise ValidationError("Action must be 'Add' or 'Remove'")
 
 class PutMembersRequestSerializer(serializers.Serializer):
     action = serializers.CharField(validators=[validate_action_field])

--- a/policykit/policykit/urls.py
+++ b/policykit/policykit/urls.py
@@ -6,7 +6,7 @@ from django.contrib import admin
 from django.contrib.auth import views
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
-from policyengine import views as policyviews
+from policyengine import views as policyviews, api_views as policyapiviews
 from policyengine.metagov_app import metagov_handler
 
 # from schema_graph.views import Schema
@@ -85,6 +85,7 @@ urlpatterns = [
     path('api/hooks/<slug:plugin_name>/<slug:community_slug>', handle_incoming_webhook),
     path('api/hooks/<slug:plugin_name>/<slug:community_slug>/<slug:community_platform_id>', handle_incoming_webhook),
     # path("schema/", Schema.as_view()),
+    path('api/members', policyapiviews.members),
 ]
 
 if apps.is_installed("pattern_library"):

--- a/policykit/tests/test_api_views.py
+++ b/policykit/tests/test_api_views.py
@@ -1,0 +1,146 @@
+from rest_framework.test import APITestCase
+
+import tests.utils as TestUtils
+
+from policyengine.models import CommunityRole, Policy
+
+class APIViewsTestCase(APITestCase):
+
+    def setUp(self):
+        self.slack_community, self.user = TestUtils.create_slack_community_and_user()
+        self.community = self.slack_community.community
+        self.constitution_community = self.community.constitution_community
+
+        # immediately pass all actions so we can assert that their results immediately
+        Policy.objects.create(
+            **TestUtils.ALL_ACTIONS_PASS,
+            kind=Policy.CONSTITUTION,
+            community=self.community,
+        )
+
+
+    def test_get_members(self):
+        self.client.force_login(user=self.user, backend="integrations.slack.auth_backends.SlackBackend")
+        response = self.client.get('/api/members')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+        user_0 = response.data[0]
+        self.assertEqual(user_0['id'], self.user.id)
+        self.assertEqual(user_0['name'], 'user1')
+        self.assertEqual(len(user_0['roles']), 1)
+        self.assertEqual(user_0['roles'][0]['name'], 'fake role')
+
+    def test_put_members_can_assign_member_roles(self):
+        self.client.force_login(user=self.user, backend="integrations.slack.auth_backends.SlackBackend")
+        role = CommunityRole.objects.create(
+            role_name="test role", community=self.community)
+        user_2 = TestUtils.create_user_in_slack_community(self.slack_community, "user_2")
+        user_3 = TestUtils.create_user_in_slack_community(self.slack_community, "user_3")
+        
+        # when a request is made to add 2 users to a role they do not have
+        response = self.client.put(
+            '/api/members',
+            data={'action': 'assign', 'role': role.id, 'members': [user_2.pk, user_3.pk]},
+            format='multipart'
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # then the new roles appear in the member list
+        test_resp = self.client.get('/api/members')
+        self.assertEqual(len(test_resp.data), 3)
+
+        user_2_resp = next(u for u in test_resp.data if u['id'] == user_2.pk)
+        self.assertIsNotNone(user_2_resp)
+        user_2_role_ids = [r['id'] for r in user_2_resp['roles']]
+        self.assertTrue(set(user_2_role_ids).issuperset({role.id}))
+
+        user_3_resp = next(u for u in test_resp.data if u['id'] == user_3.pk)
+        self.assertIsNotNone(user_3_resp)
+        user_3_role_ids = [r['id'] for r in user_3_resp['roles']]
+        self.assertTrue(set(user_3_role_ids).issuperset({role.id}))
+
+    def test_put_members_can_revoke_member_roles(self):
+        self.client.force_login(user=self.user, backend="integrations.slack.auth_backends.SlackBackend")
+        role = CommunityRole.objects.create(
+            role_name="test role", community=self.community)
+        user_2 = TestUtils.create_user_in_slack_community(self.slack_community, "user_2")
+        user_3 = TestUtils.create_user_in_slack_community(self.slack_community, "user_3")
+        
+        # given users have the roles
+        fixture_resp = self.client.put(
+            '/api/members',
+            data={'action': 'assign', 'role': role.id, 'members': [user_2.pk, user_3.pk]},
+            format='multipart'
+        )
+        self.assertEqual(fixture_resp.status_code, 200)
+
+        # when they are revoked
+        resp = self.client.put(
+            '/api/members',
+            data={'action': 'revoke', 'role': role.id, 'members': [user_2.pk, user_3.pk]},
+            format='multipart'
+        )
+        self.assertEqual(fixture_resp.status_code, 200)
+
+        # then the new roles no longer appear in the member list
+        test_resp = self.client.get('/api/members')
+        self.assertEqual(len(test_resp.data), 3)
+
+        user_2_resp = next(u for u in test_resp.data if u['id'] == user_2.pk)
+        self.assertIsNotNone(user_2_resp)
+        user_2_role_ids = [r['id'] for r in user_2_resp['roles']]
+        self.assertTrue(set(user_2_role_ids).isdisjoint({role.id}))
+
+        user_3_resp = next(u for u in test_resp.data if u['id'] == user_3.pk)
+        self.assertIsNotNone(user_3_resp)
+        user_3_role_ids = [r['id'] for r in user_3_resp['roles']]
+        self.assertTrue(set(user_3_role_ids).isdisjoint({role.id}))
+
+    def test_put_members_responds_400_on_invalid_body(self):
+        self.client.force_login(user=self.user, backend="integrations.slack.auth_backends.SlackBackend")
+        response = self.client.put(
+            '/api/members',
+            data={'action': 'foobar', 'role': 1, 'members': [1]},  # action is not 'assign' or 'revoke'
+            format='multipart'
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_put_members_responds_404_if_role_exists_in_different_community(self):
+        other_community, _ = TestUtils.create_slack_community_and_user(team_id="OTH", username="otheruser")
+        role = CommunityRole.objects.create(
+            role_name="other role", community=other_community.community)
+        user_2 = TestUtils.create_user_in_slack_community(self.slack_community, "user_2")
+        self.client.force_login(user=self.user, backend="integrations.slack.auth_backends.SlackBackend")
+
+        # when a request is made to add 2 users to a role they do not have
+        response = self.client.put(
+            '/api/members',
+            data={'action': 'assign', 'role': role.id, 'members': [user_2.pk]},
+            format='multipart'
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_put_members_responds_404_if_user_exists_in_different_community(self):
+        _, other_user = TestUtils.create_slack_community_and_user(team_id="OTH", username="otheruser")
+        role = CommunityRole.objects.create(
+            role_name="test role", community=self.community)
+
+        self.client.force_login(user=self.user, backend="integrations.slack.auth_backends.SlackBackend")
+
+        # when a request is made to add 2 users to a role they do not have
+        response = self.client.put(
+            '/api/members',
+            data={'action': 'assign', 'role': role.id, 'members': [other_user.pk]},
+            format='multipart'
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_put_members_responds_403_on_anon_user(self):
+        response = self.client.put(
+            '/api/members',
+            data={'action': 'assign', 'role': 1, 'members': [1]},  # action is missing
+            format='multipart'
+        )
+        self.assertEqual(response.status_code, 403)

--- a/policykit/tests/test_api_views.py
+++ b/policykit/tests/test_api_views.py
@@ -11,7 +11,7 @@ class APIViewsTestCase(APITestCase):
         self.community = self.slack_community.community
         self.constitution_community = self.community.constitution_community
 
-        # immediately pass all actions so we can assert that their results immediately
+        # immediately pass all actions so we can assert their results immediately
         Policy.objects.create(
             **TestUtils.ALL_ACTIONS_PASS,
             kind=Policy.CONSTITUTION,
@@ -32,7 +32,7 @@ class APIViewsTestCase(APITestCase):
         self.assertEqual(len(user_0['roles']), 1)
         self.assertEqual(user_0['roles'][0]['name'], 'fake role')
 
-    def test_put_members_can_assign_member_roles(self):
+    def test_put_members_can_add_member_roles(self):
         self.client.force_login(user=self.user, backend="integrations.slack.auth_backends.SlackBackend")
         role = CommunityRole.objects.create(
             role_name="test role", community=self.community)
@@ -42,7 +42,7 @@ class APIViewsTestCase(APITestCase):
         # when a request is made to add 2 users to a role they do not have
         response = self.client.put(
             '/api/members',
-            data={'action': 'assign', 'role': role.id, 'members': [user_2.pk, user_3.pk]},
+            data={'action': 'Add', 'role': role.id, 'members': [user_2.pk, user_3.pk]},
             format='multipart'
         )
         self.assertEqual(response.status_code, 200)
@@ -61,7 +61,7 @@ class APIViewsTestCase(APITestCase):
         user_3_role_ids = [r['id'] for r in user_3_resp['roles']]
         self.assertTrue(set(user_3_role_ids).issuperset({role.id}))
 
-    def test_put_members_can_revoke_member_roles(self):
+    def test_put_members_can_remove_member_roles(self):
         self.client.force_login(user=self.user, backend="integrations.slack.auth_backends.SlackBackend")
         role = CommunityRole.objects.create(
             role_name="test role", community=self.community)
@@ -71,15 +71,15 @@ class APIViewsTestCase(APITestCase):
         # given users have the roles
         fixture_resp = self.client.put(
             '/api/members',
-            data={'action': 'assign', 'role': role.id, 'members': [user_2.pk, user_3.pk]},
+            data={'action': 'Add', 'role': role.id, 'members': [user_2.pk, user_3.pk]},
             format='multipart'
         )
         self.assertEqual(fixture_resp.status_code, 200)
 
-        # when they are revoked
+        # when they are removed 
         resp = self.client.put(
             '/api/members',
-            data={'action': 'revoke', 'role': role.id, 'members': [user_2.pk, user_3.pk]},
+            data={'action': 'Remove', 'role': role.id, 'members': [user_2.pk, user_3.pk]},
             format='multipart'
         )
         self.assertEqual(fixture_resp.status_code, 200)
@@ -102,7 +102,7 @@ class APIViewsTestCase(APITestCase):
         self.client.force_login(user=self.user, backend="integrations.slack.auth_backends.SlackBackend")
         response = self.client.put(
             '/api/members',
-            data={'action': 'foobar', 'role': 1, 'members': [1]},  # action is not 'assign' or 'revoke'
+            data={'action': 'foobar', 'role': 1, 'members': [1]},  # action is not 'Add' or 'Remove'
             format='multipart'
         )
         self.assertEqual(response.status_code, 400)
@@ -117,7 +117,7 @@ class APIViewsTestCase(APITestCase):
         # when a request is made to add 2 users to a role they do not have
         response = self.client.put(
             '/api/members',
-            data={'action': 'assign', 'role': role.id, 'members': [user_2.pk]},
+            data={'action': 'Add', 'role': role.id, 'members': [user_2.pk]},
             format='multipart'
         )
         self.assertEqual(response.status_code, 404)
@@ -132,7 +132,7 @@ class APIViewsTestCase(APITestCase):
         # when a request is made to add 2 users to a role they do not have
         response = self.client.put(
             '/api/members',
-            data={'action': 'assign', 'role': role.id, 'members': [other_user.pk]},
+            data={'action': 'Add', 'role': role.id, 'members': [other_user.pk]},
             format='multipart'
         )
         self.assertEqual(response.status_code, 404)
@@ -140,7 +140,7 @@ class APIViewsTestCase(APITestCase):
     def test_put_members_responds_403_on_anon_user(self):
         response = self.client.put(
             '/api/members',
-            data={'action': 'assign', 'role': 1, 'members': [1]},  # action is missing
+            data={'action': 'Add', 'role': 1, 'members': [1]},  # action is missing
             format='multipart'
         )
         self.assertEqual(response.status_code, 403)

--- a/policykit/tests/utils.py
+++ b/policykit/tests/utils.py
@@ -56,3 +56,6 @@ def create_slack_and_discord_community():
     DiscordCommunity.objects.create(
         community_name="discord test community", community=slack_comm.community, team_id="123"
     )
+
+def create_user_in_slack_community(community: SlackCommunity, username: str):
+    return SlackUser.objects.create(username=username, community=community)


### PR DESCRIPTION
This PR implements the `/api/members` endpoint, as described in the api doc and in Slack discussions.

I started by copying the logic from `policyengine.views.role_action_users`. It remains mostly a straight copy from there, with a bit of tightening to prevent assigning roles across communities. I'm not 100% what the rules are there, so please check I haven't made it impossible to assign roles in related communities where it should work. I could not identify tests which covered that view, so I've written my own for the new one. 

This is the first DRF views for the project. Please don't hesitate to request changes if there's a different style or idiom that the project would like to use.