### PR TITLE
#626 implement `/api/dashboard` endpoint

### DIFF
--- a/policykit/policyengine/api_views.py
+++ b/policykit/policyengine/api_views.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from rest_framework.exceptions import NotFound 
 from django.contrib.auth import get_user
 from django.db import transaction
-from policyengine.serializers import MemberSummarySerializer, PutMembersRequestSerializer
+from policyengine.serializers import MemberSummarySerializer, PutMembersRequestSerializer, CommunityDashboardSerializer
 
 @api_view(['GET', 'PUT'])
 @permission_classes([IsAuthenticated])
@@ -25,6 +25,12 @@ def members(request):
         return Response({}, status=200)
 
     raise NotImplemented
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def dashboard(request):
+    user = get_user(request)
+    return Response(CommunityDashboardSerializer(user.community.community).data)
 
 def get_members(user):
     from policyengine.models import CommunityUser
@@ -57,3 +63,4 @@ def put_members(user, action, role, members):
     if len(action_model.users.all()) != len(members):
         raise NotFound('User not found')
     action_model.save(evaluate_action=True)
+

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -73,9 +73,24 @@ class Community(models.Model):
         return CommunityDoc.objects.filter(community=self, is_active=is_active)
 
     @property
+    def community_doc(self):
+        """
+        The community doc is the most recent active document associated with
+        the comunity
+        """
+        return CommunityDoc.objects.filter(community=self).last()
+
+    @property
     def constitution_community(self):
         from constitution.models import ConstitutionCommunity
         return ConstitutionCommunity.objects.filter(community=self).first()
+
+    @property
+    def proposals(self):
+        """
+        Returns a QuerySet of all proposals in the community.
+        """
+        return Proposal.objects.filter(policy__community=self)
 
     def get_platform_communities(self):
         constitution_community = self.constitution_community

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -73,14 +73,6 @@ class Community(models.Model):
         return CommunityDoc.objects.filter(community=self, is_active=is_active)
 
     @property
-    def community_doc(self):
-        """
-        The community doc is the most recent active document associated with
-        the comunity
-        """
-        return CommunityDoc.objects.filter(community=self).last()
-
-    @property
     def constitution_community(self):
         from constitution.models import ConstitutionCommunity
         return ConstitutionCommunity.objects.filter(community=self).first()

--- a/policykit/policyengine/serializers.py
+++ b/policykit/policyengine/serializers.py
@@ -49,9 +49,14 @@ class ProposalSummarySerializer(serializers.Serializer):
     initiator = InitiatorSummarySerializer(source='action.initiator')
     policy = PolicySummarySerializer()
 
+class CommunityDocSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    text = serializers.CharField()
+
 class CommunityDashboardSerializer(serializers.Serializer):
     roles = DashboardRoleSummarySerializer(many=True, source='get_roles')
-    community_doc = serializers.CharField(source='community_doc.text', allow_null=True)
+    community_docs = CommunityDocSerializer(source='get_documents', many=True)
     platform_policies = PolicySummarySerializer(many=True, source='get_platform_policies')
     constitution_policies = PolicySummarySerializer(many=True, source='get_constitution_policies')
     proposals = ProposalSummarySerializer(many=True)

--- a/policykit/policyengine/serializers.py
+++ b/policykit/policyengine/serializers.py
@@ -19,3 +19,39 @@ class PutMembersRequestSerializer(serializers.Serializer):
     action = serializers.CharField(validators=[validate_action_field])
     role = serializers.IntegerField()  # pk of role to assign
     members = serializers.ListField(child=serializers.IntegerField())  # list of user pks to assign to role
+
+class DashboardRoleSummarySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField(source='role_name')
+    description = serializers.CharField()
+    number_of_members = serializers.IntegerField(source='user_set.count', min_value=0)
+
+class PolicySummarySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    description = serializers.CharField()
+    # platform = serializers.CharField()
+
+class ActionSummarySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    action_type = serializers.CharField()
+
+class InitiatorSummarySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    readable_name = serializers.CharField()
+
+class ProposalSummarySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    status = serializers.CharField()
+    proposal_time = serializers.DateTimeField()  # TODO check this is utc
+    is_vote_closed = serializers.BooleanField()
+    action = ActionSummarySerializer()
+    initiator = InitiatorSummarySerializer(source='action.initiator')
+    policy = PolicySummarySerializer()
+
+class CommunityDashboardSerializer(serializers.Serializer):
+    roles = DashboardRoleSummarySerializer(many=True, source='get_roles')
+    community_doc = serializers.CharField(source='community_doc.text', allow_null=True)
+    platform_policies = PolicySummarySerializer(many=True, source='get_platform_policies')
+    constitution_policies = PolicySummarySerializer(many=True, source='get_constitution_policies')
+    proposals = ProposalSummarySerializer(many=True)

--- a/policykit/policykit/urls.py
+++ b/policykit/policykit/urls.py
@@ -86,6 +86,7 @@ urlpatterns = [
     path('api/hooks/<slug:plugin_name>/<slug:community_slug>/<slug:community_platform_id>', handle_incoming_webhook),
     # path("schema/", Schema.as_view()),
     path('api/members', policyapiviews.members),
+    path('api/dashboard', policyapiviews.dashboard),
 ]
 
 if apps.is_installed("pattern_library"):


### PR DESCRIPTION
This implements the `/api/dashboard` endpoint as described in the api doc, and in discussion on slack. 

However, I was not able to get a `closed_time` for a Proposal. AFAIKT there is no record of the end time of a proposal. I have instead serialized the `is_vote_closed` property on `Proposal`. Please let me know if I've missed something there.

### Example response body

```
{
  "roles": [
    {
      "id": 1,
      "name": "Base User",
      "description": "",
      "number_of_members": 2
    },
    {
      "id": 2,
      "name": "Integration Admin",
      "description": "",
      "number_of_members": 2
    }
  ],
  "community_doc": "This is a test document.",
  "platform_policies": [
    {
      "id": 3,
      "name": "Test Policy",
      "description": ""
    },
    {
      "id": 1,
      "name": "All Platform Actions Pass",
      "description": "All platform actions pass automatically"
    }
  ],
  "constitution_policies": [
    {
      "id": 2,
      "name": "All Constitution Actions Pass",
      "description": "All constitution actions pass automatically"
    }
  ],
  "proposals": [
    {
      "id": 1,
      "status": "passed",
      "proposal_time": "2024-03-09T03:25:08.653763Z",
      "is_vote_closed": true,
      "action": {
        "id": 1,
        "action_type": "policykitadduserrole"
      },
      "initiator": {
        "id": 1,
        "readable_name": "d.douglas.carr"
      },
      "policy": {
        "id": 2,
        "name": "All Constitution Actions Pass",
        "description": "All constitution actions pass automatically"
      }
    },
    {
      "id": 2,
      "status": "passed",
      "proposal_time": "2024-03-09T03:25:45.363079Z",
      "is_vote_closed": true,
      "action": {
        "id": 2,
        "action_type": "policykitaddcommunitydoc"
      },
      "initiator": {
        "id": 1,
        "readable_name": "d.douglas.carr"
      },
      "policy": {
        "id": 2,
        "name": "All Constitution Actions Pass",
        "description": "All constitution actions pass automatically"
      }
    },
    {
      "id": 3,
      "status": "passed",
      "proposal_time": "2024-03-09T05:20:48.448574Z",
      "is_vote_closed": true,
      "action": {
        "id": 3,
        "action_type": "policykitaddplatformpolicy"
      },
      "initiator": {
        "id": 1,
        "readable_name": "d.douglas.carr"
      },
      "policy": {
        "id": 2,
        "name": "All Constitution Actions Pass",
        "description": "All constitution actions pass automatically"
      }
    }
  ]
}
```
