### PR TITLE
Add support for local slack install with nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,23 +6,27 @@ services:
       - ./policykit:/app
     ports:
       - "8000:8000"
-    env_file: "policykit/policykit/.env"
+    env_file: ".env"
     environment:
       - CELERY_BROKER_URL=amqp://guest:guest@rabbit:5672/
       - DATABASE_URL=postgres://user:password@postgres:5432/policykit
       - DJANGO_SECRET_KEY=supersecretkey
-      - SERVER_URL=https://${SUBDOMAIN}.loca.lt
-      - ALLOWED_HOSTS=web,.localhost,127.0.0.1,[::1]
+      - SERVER_URL=https://${DOMAIN}
+      - ALLOWED_HOSTS=web,.localhost,127.0.0.1,[::1],${DOMAIN}
     depends_on:
       - rabbit
       - postgres
 
-  localtunnel:
-    env_file: "policykit/policykit/.env"
-    build: ./policykit/localtunnel/
-    command: lt --port 8000 --local-host web --subdomain ${SUBDOMAIN}
+  ngrok:
+    image: ngrok/ngrok:latest
     depends_on:
       - web
+    command:
+      - "http"
+      - "http://host.docker.internal:8000"
+      - "--domain=${DOMAIN}"
+    environment:
+      NGROK_AUTHTOKEN: ${NGROK_AUTHTOKEN}
 
   celery:
     build: ./policykit/
@@ -30,7 +34,7 @@ services:
     command: "celery -A policykit worker --loglevel=info"
     volumes:
       - ./policykit:/app
-    env_file: "policykit/policykit/.env"
+    env_file: ".env"
     environment:
       - CELERY_BROKER_URL=amqp://guest:guest@rabbit:5672/
       - DATABASE_URL=postgres://user:password@postgres:5432/policykit
@@ -42,7 +46,7 @@ services:
     build: ./policykit/
     user: django-user
     command: "celery -A policykit beat --loglevel=info"
-    env_file: "policykit/policykit/.env"
+    env_file: ".env"
     volumes:
       - ./policykit:/app
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,23 @@ services:
       - ./policykit:/app
     ports:
       - "8000:8000"
+    env_file: "policykit/policykit/.env"
     environment:
       - CELERY_BROKER_URL=amqp://guest:guest@rabbit:5672/
       - DATABASE_URL=postgres://user:password@postgres:5432/policykit
-      - DEBUG=True
       - DJANGO_SECRET_KEY=supersecretkey
-      - SERVER_URL=localhost:8000
+      - SERVER_URL=https://${SUBDOMAIN}.loca.lt
+      - ALLOWED_HOSTS=web
     depends_on:
       - rabbit
       - postgres
+
+  localtunnel:
+    env_file: "policykit/policykit/.env"
+    build: ./policykit/localtunnel/
+    command: lt --port 8000 --local-host web --subdomain ${SUBDOMAIN}
+    depends_on:
+      - web
 
   celery:
     build: ./policykit/
@@ -22,6 +30,7 @@ services:
     command: "celery -A policykit worker --loglevel=info"
     volumes:
       - ./policykit:/app
+    env_file: "policykit/policykit/.env"
     environment:
       - CELERY_BROKER_URL=amqp://guest:guest@rabbit:5672/
       - DATABASE_URL=postgres://user:password@postgres:5432/policykit
@@ -33,6 +42,7 @@ services:
     build: ./policykit/
     user: django-user
     command: "celery -A policykit beat --loglevel=info"
+    env_file: "policykit/policykit/.env"
     volumes:
       - ./policykit:/app
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - DATABASE_URL=postgres://user:password@postgres:5432/policykit
       - DJANGO_SECRET_KEY=supersecretkey
       - SERVER_URL=https://${SUBDOMAIN}.loca.lt
-      - ALLOWED_HOSTS=web
+      - ALLOWED_HOSTS=web,.localhost,127.0.0.1,[::1]
     depends_on:
       - rabbit
       - postgres
@@ -59,7 +59,6 @@ services:
       - 15672:15672
 
   postgres:
-    container_name: postgresql
     image: postgres:alpine
     environment:
       - POSTGRES_DB=policykit
@@ -68,4 +67,6 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./postgres_data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
+volumes:
+  postgres-data:

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -84,8 +84,8 @@ You can also deploy PolicyKit using Docker.
 
 .. code-block:: shell
 
-	docker compose run web python3 manage.py makemigrations
-        docker compose run web python3 manage.py migrate
+	docker compose run --rm web python3 manage.py makemigrations
+        docker compose run --rm web python3 manage.py migrate
 
 5. Finally, to run PolicyKit and all its services run:
 

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -17,7 +17,7 @@ PolicyKit requires Python 3. Our guide recommends that you manage the repository
 	git clone https://github.com/policykit/policykit.git
 	cd policykit
 
-2. Install Python3, create a virtual environment for Policykit, and ensure your environment is using the latest version of pip: 
+2. Install Python3, create a virtual environment for Policykit, and ensure your environment is using the latest version of pip:
 
 .. code-block:: shell
 
@@ -42,7 +42,7 @@ Your terminal prompt should change to look something like this ``(policykit_venv
 	cd policykit
 	cp .env.example .env
 
-To run PolicyKit in production, you'll need to change some values in the ``.env`` file such as the ``DJANGO_SECRET_KEY`` and ``SERVER_URL``. 
+To run PolicyKit in production, you'll need to change some values in the ``.env`` file such as the ``DJANGO_SECRET_KEY`` and ``SERVER_URL``.
 
 For local development, all you need to do is set ``DEBUG=true``.
 
@@ -75,10 +75,20 @@ You can also deploy PolicyKit using Docker.
 
 1. Make sure to have Docker and Docker Compose installed.
 
-2. Clone the repo, navigate to the root and create an ``policykit/policykit/.env`` file as on the previous guide.
+2. Clone the repo, navigate to the root and create a copy of ``policykit/policykit/.env.example`` as ``.env``:
 
-3. Choose a subdomain for your PolicyKit instance. This is neccessary for Slack integration and for signin.
-   Add `SUBDOMAIN=yoursubdomain` to the .env file.
+   .. code-block:: shell
+
+        cp policykit/policykit/.env.example .env
+
+3. Create a ngrok account and [claim your free static domain](https://ngrok.com/blog-post/free-static-domains-ngrok-users).
+   Then add your domain and auth token to the ``.env`` file:
+
+.. code-block:: shell
+
+        DOMAIN=xyz.ngrok-free.app
+        NGROK_AUTHTOKEN=467...
+
 
 4. Next, to create and set up the database run the following commands:
 
@@ -93,9 +103,9 @@ You can also deploy PolicyKit using Docker.
 
 	docker compose up
 
-6. Then you can access PolicyKit in the browser at ``http://localhost:8000`` or ``https://<subdomain>.loca.lt``.
+6. Then you can access PolicyKit in the browser at ``http://localhost:8000`` or ``https://<DOMAIN>``.
 
-7. To be able to sign in, follow the steps below for setting up Slack. Use ``https://<subdomain>.loca.lt`` as your web address.
+7. To be able to sign in, follow the steps below for setting up Slack. Use ``https://<DOMAIN>`` as your web address.
 
 
 Running PolicyKit on a Server
@@ -111,7 +121,7 @@ Thus far, we have run Policykit in Ubuntu 18.04 and Ubuntu 20.04. The instructio
 		cd policykit
 
 2. Install Python3, create a virtual environment for PolicyKit, and ensure your environment is using the latest version of pip:
-         
+
 	.. code-block:: shell
 
 		sudo apt install python3-pip python3-venv
@@ -129,12 +139,12 @@ Your terminal prompt should change to look something like this ``(policykit_venv
 		pip install -r requirements.txt
 
 4. Next, run the following commands to create an ``.env`` file to store your settings and secrets:
-           
+
 	.. code-block:: shell
 
 		cd policykit
 		cp .env.example .env
- 
+
 5. Generate a secret key for Django using this command:
 
 	.. code-block:: shell
@@ -171,7 +181,7 @@ By default, PolicyKit will create a sqlite3 database in the root directory. If y
 Deploy with Apache web server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Now that you have PolicyKit installed on your server, you can deploy it on Apache web server. 
+Now that you have PolicyKit installed on your server, you can deploy it on Apache web server.
 
 Make sure you have a domain dedicated to Policykit that is pointing to your server's IP address.
 
@@ -188,7 +198,7 @@ Make sure you have a domain dedicated to Policykit that is pointing to your serv
 1. Install apache2 and the apache module Web Server Gateway Interface:
 
 	.. code-block:: shell
-        
+
         	sudo apt-get install apache2 libapache2-mod-wsgi-py3
 
 2. Create a new apache2 config file:
@@ -209,8 +219,8 @@ Make sure you have a domain dedicated to Policykit that is pointing to your serv
                         	ServerAdmin webmaster@localhost
                         	Alias /static $POLICYKIT_REPO/policykit/static
                         	DocumentRoot $POLICYKIT_REPO
-                        
-                        	# Grant access to the static site 
+
+                        	# Grant access to the static site
                         	<Directory $POLICYKIT_REPO/policykit/static>
                                 	Require all granted
                         	</Directory>
@@ -221,7 +231,7 @@ Make sure you have a domain dedicated to Policykit that is pointing to your serv
                                         	Require all granted
                                 	</Files>
                         	</Directory>
-                        
+
                         	# Setup the WSGI Daemon
                         	WSGIDaemonProcess policykit python-home=$POLICYKIT_ENV python-path=$POLICYKIT_REPO/policykit
                         	WSGIProcessGroup policykit
@@ -259,19 +269,19 @@ Make sure you have a domain dedicated to Policykit that is pointing to your serv
 8. Reload the config:
 
 	.. code-block:: shell
-        
+
 		systemctl reload apache2
 
 9. Give the Apache2 user (aka ``www-data``) access to the Django log directory and the database directory. Update paths as needed based on personal setup:
 
 	.. code-block:: shell
-        
+
         	sudo chown -R www-data:www-data /var/log/django/policykit/
         	sudo chown -R www-data:www-data /var/databases/policykit/
 
 10. Load your site in the browser and navigate to ``/login``. You should see a site titled "PolicKiy Administration" with options to connect to Slack, Discourse, and Discord. Before you can install PolicyKit into any of these platforms, you'll need to set the necessary Client IDs and Client Secrets in ``.env``. Follow the setup instructions for these and other integrations in :doc:`Integrations <integrations>`.
 
-  Check for errors at ``/var/log/apache2/error.log`` and ``/var/log/django/policykit/debug.log`` (or whatever logging path you set in ``.env``). 
+  Check for errors at ``/var/log/apache2/error.log`` and ``/var/log/django/policykit/debug.log`` (or whatever logging path you set in ``.env``).
 
 11. Any time you update the code, you'll need to run ``systemctl reload apache2`` to reload the server.
 
@@ -286,7 +296,7 @@ Create celery user
 If you don't already have a ``celery`` user, create one:
 
 .. code-block:: bash
-        
+
         sudo useradd celery -d /home/celery -b /bin/bash
 
 Give the ``celery`` user access to necessary pid and log folders:
@@ -321,14 +331,14 @@ The ``celery`` user will also need write access to the Django log file and the d
 Create Celery configuration files
 """""""""""""""""""""""""""""""""
 
-Next, you'll need to create three Celery configuration files for PolicyKit 
+Next, you'll need to create three Celery configuration files for PolicyKit
 
 .. note::
 
         Remember to substitute the following variables with an absolute path:
-        
+
         ``$POLICYKIT_ENV`` is the path to your policykit virtual environment. (i.e. ``/var/www/policykit/policykit_venv``)
-        
+
         ``$POLICYKIT_REPO`` is the path to your policykit repository root. (i.e. ``/var/www/policykit``)
 
 ``/etc/conf.d/celery``
@@ -429,7 +439,7 @@ Next, install RabbitMQ, a message broker:
 
 Enable and start the RabbitMQ service:
 
-:: 
+::
 
  sudo systemctl enable rabbitmq-server
  sudo service rabbitmq-server start
@@ -444,7 +454,7 @@ Check the status to make sure everything is running smoothly:
 Finally, run the following commands to start the celery daemon:
 
 ::
- 
+
  sudo systemctl start celery celerybeat
 
 
@@ -527,7 +537,7 @@ Visit https://api.slack.com/apps and click the "Create New App" button, and then
 
 Give your app a name and pick a workspace to develop your app in.
 
-You must be the admin of the workspace to add a new app. If you are not an admin of any current workspace you can create a new workspace. 
+You must be the admin of the workspace to add a new app. If you are not an admin of any current workspace you can create a new workspace.
 
 Go to the "Basic Information" page and under "Building Apps for Slack", expand the "Add features and functionality section". We will work our way through each subsection detailing how to configure your application.
 
@@ -535,11 +545,11 @@ Go to the "Basic Information" page and under "Building Apps for Slack", expand t
 
 **Incoming Webhooks**
 
-Activate the toggle from off to on in this section. 
+Activate the toggle from off to on in this section.
 
 **Interactive Components**
 
-Activate the toggle from off to on in this section. 
+Activate the toggle from off to on in this section.
 
 Enter the following URL in the Request URL box (changing $SERVER_NAME for the server url you setup above): ``https://$SERVER_NAME/api/hooks/slack``
 
@@ -549,14 +559,14 @@ No changes needed.
 
 **Event Subscriptions**
 
-Activate the toggle from off to on in this section. 
+Activate the toggle from off to on in this section.
 
 Enter the following URL in the Request URL box (changing $SERVER_NAME for the server url you setup above): ``https://$SERVER_NAME/api/hooks/slack``
 
 Bots
 """"""""""""""""""""""""""""""""""""""""""""""""""""
 
-Activate the toggle from off to on for Always Show My Bot as Online. 
+Activate the toggle from off to on for Always Show My Bot as Online.
 
 **Permissions**
 
@@ -608,7 +618,7 @@ We recommend adding the following scopes to your app for testing PolicyKit with 
 
 **Install Your App**
 
-After defining scopes you are able to install your app to your Slack workspace to test it and generate API tokens. 
+After defining scopes you are able to install your app to your Slack workspace to test it and generate API tokens.
 
 Go back to the "Basic Information" page and expand the "Install your App section". Then click "Install to Workspace".
 
@@ -621,13 +631,13 @@ Add these values to your ``.env`` in ``$POLICY_REPO/policykit/policykit/.env``
 Reload the Apache server
 
 ::
- 
+
  systemctl reload apache2
 
 
 **Connecting PolicyKit to Your Slack App**
 
-You can now visit your PolicyKit login page ``$SERVER_NAME/login`` and "Install Policykit to Slack". 
+You can now visit your PolicyKit login page ``$SERVER_NAME/login`` and "Install Policykit to Slack".
 
 You will be prompted to authorize the the app to access your workspace.
 
@@ -645,7 +655,7 @@ If you plan to allow other Slack workspaces to use your PolicyKit server, you wi
 
 Discord
 """""""
-The Discord integration occurs through Metagov. Instructions for how to setup the plugin for Metagov Discord to be written. 
+The Discord integration occurs through Metagov. Instructions for how to setup the plugin for Metagov Discord to be written.
 
 Discourse
 """""""""

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -75,20 +75,27 @@ You can also deploy PolicyKit using Docker.
 
 1. Make sure to have Docker and Docker Compose installed.
 
-2. Clone the repo, navigate to the root and create an ``.env`` file as on the previous guide:
+2. Clone the repo, navigate to the root and create an ``policykit/policykit/.env`` file as on the previous guide.
 
-3. Next, to create and set up the database run the following commands:
+3. Choose a subdomain for your PolicyKit instance. This is neccessary for Slack integration and for signin.
+   Add `SUBDOMAIN=yoursubdomain` to the .env file.
+
+4. Next, to create and set up the database run the following commands:
 
 .. code-block:: shell
 
 	docker compose run web python3 manage.py makemigrations
         docker compose run web python3 manage.py migrate
 
-4. Finally, to run PolicyKit and all its services run:
+5. Finally, to run PolicyKit and all its services run:
 
 .. code-block:: shell
 
 	docker compose up
+
+6. Then you can access PolicyKit in the browser at ``http://localhost:8000`` or ``https://<subdomain>.loca.lt``.
+
+7. To be able to sign in, follow the steps below for setting up Slack. Use ``https://<subdomain>.loca.lt`` as your web address.
 
 
 Running PolicyKit on a Server

--- a/policykit/Dockerfile
+++ b/policykit/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR app
 
 COPY requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt && \ 
-    adduser \                                           
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt
+RUN adduser \
         --disabled-password \
         --no-create-home \
         django-user

--- a/policykit/Dockerfile
+++ b/policykit/Dockerfile
@@ -15,3 +15,6 @@ COPY policykit app
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
 
 USER django-user
+
+# https://stackoverflow.com/a/67832444
+ENV PYTHONUNBUFFERED=1

--- a/policykit/localtunnel/Dockerfile
+++ b/policykit/localtunnel/Dockerfile
@@ -1,0 +1,4 @@
+FROM node
+
+RUN npm install -g localtunnel
+

--- a/policykit/localtunnel/Dockerfile
+++ b/policykit/localtunnel/Dockerfile
@@ -1,4 +1,0 @@
-FROM node
-
-RUN npm install -g localtunnel
-


### PR DESCRIPTION
This PR builds on @franciclo's work in #361 to support login locally using ~~[localtunnel](https://github.com/localtunnel/localtunnel). I choose to use that instead of ngrok because it doesn't require an account.~~

~~However, if we encounter any issues with it, we could switch to ngrok.~~

EDIT: This PR now uses ngrok because I found localtunnel to be unstable. It does require a free ngrok account.

You can manually put in a requested subdomain, and then that will be used to create your public account which you can then create a slack app for.

I tested this and it seems to work. Note that I tried it at first under a slack workspace where I was not an admin and it failed, so make sure to try it with an admin workspace.