### PR TITLE
Use different DSN for client

### DIFF
--- a/policykit/policykit/.env.example
+++ b/policykit/policykit/.env.example
@@ -35,5 +35,5 @@ GITHUB_APP_ID=
 GITHUB_PRIVATE_KEY_PATH=
 
 # Include if you would like sentry error tracking
-# SENTRY_DSN=...
-# SENTRY_JS_SCRIPT=https://js.sentry-cdn.com/[examplePublicKey].min.js
+# SENTRY_SERVER_DSN=...
+# SENTRY_CLIENT_SCRIPT=https://js.sentry-cdn.com/[examplePublicKey].min.js

--- a/policykit/policykit/sentry.py
+++ b/policykit/policykit/sentry.py
@@ -11,14 +11,17 @@ SENTRY_SCRIPT = '<script id="sentry-script" src="https://browser.sentry-cdn.com/
 
 @register.simple_tag
 def sentry():
-    DSN = settings.SENTRY_DSN
-    if not DSN:
+    """
+    Insert script tag for Sentry and initialize it, if `SENTRY_CLIENT_SCRIPT` is set.
+    """
+    script = settings.SENTRY_CLIENT_SCRIPT
+    if not script:
         return ''
 
-    meta = trace_propagation_meta(sentry_sdk.Hub.current)
-    html = f"""{SENTRY_SCRIPT}
-  {meta}
-  <script>Sentry.init({{dsn: {DSN!r}, integrations: [Sentry.browserTracingIntegration()]}});</script>
+    html = f"""{trace_propagation_meta(sentry_sdk.Hub.current)}
+  <script src={script!r} crossorigin="anonymous"></script>
+  <script>Sentry.onLoad(function() {{Sentry.init({{integrations: [Sentry.browserTracingIntegration()]}});}});</script>
+  <script>notAReadFunction();</script>
 """
 
     return mark_safe(html)

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -29,8 +29,8 @@ env = environ.Env(
 
     # DEV SECRET! override by setting DJANGO_SECRET_KEY in .env file
     DJANGO_SECRET_KEY=(str, 'kg=&9zrc5@rern2=&+6yvh8ip0u7$f=k_zax**bwsur_z7qy+-'),
-    SENTRY_DSN=(str, None),
-    SENTRY_JS_SCRIPT=(str, None),
+    SENTRY_SERVER_DSN=(str, None),
+    SENTRY_CLIENT_SCRIPT=(str, None),
 )
 environ.Env.read_env()
 
@@ -38,14 +38,15 @@ DEBUG = env("DEBUG")
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 SERVER_URL = env("SERVER_URL")
 SECRET_KEY = env("DJANGO_SECRET_KEY")
-SENTRY_DSN = env("SENTRY_DSN")
+SENTRY_SERVER_DSN = env("SENTRY_SERVER_DSN")
+SENTRY_CLIENT_SCRIPT = env("SENTRY_CLIENT_SCRIPT")
 LOGIN_URL = "/login"
 
-if SENTRY_DSN:
+if SENTRY_SERVER_DSN:
     import sentry_sdk
 
     sentry_sdk.init(
-        dsn=SENTRY_DSN,
+        dsn=SENTRY_SERVER_DSN,
         traces_sample_rate=1.0,
     )
 


### PR DESCRIPTION
Sentry recommends creating separate projects for client and server. Follow up on #644 

I deployed this already to get error tracking working.