### PR TITLE
Fix sphinx immaterial version conflicts

### DIFF
--- a/policykit/requirements.txt
+++ b/policykit/requirements.txt
@@ -1,4 +1,4 @@
-sphinx-immaterial==0.11.2
+alabaster==0.7.13
 amqp==2.5.2
 appdirs==1.4.4
 appnope==0.1.0
@@ -8,6 +8,7 @@ attrs==20.3.0
 autopep8==1.5.6
 Babel==2.9.0
 backcall==0.1.0
+backports.zoneinfo==0.2.1
 billiard==3.6.1.0
 celery==4.4.0
 certifi==2019.11.28
@@ -15,6 +16,7 @@ cffi==1.15.1
 chardet==3.0.4
 click==7.1.2
 decorator==4.4.1
+dill==0.3.4
 Django==3.2.2
 django-activity-stream==0.10.0
 django-celery-beat==2.2.0
@@ -24,16 +26,19 @@ django-extensions==3.1.3
 django-filter==2.4.0
 django-grappelli==2.15.1
 django-jet==1.0.8
+django-pattern-library==0.6.0
 django-polymorphic==3.0.0
 django-schema-graph==1.2.0
 django-tables2==2.3.4
 django-timezone-field==4.1.2
+djangorestframework==3.15.1
 docutils==0.16
 gevent==21.12.0
 greenlet==1.1.0
 idna==2.9
 imagesize==1.2.0
 importlib-metadata==1.4.0
+importlib-resources==5.1.3
 ipython==7.11.1
 ipython-genutils==0.2.0
 isort==5.8.0
@@ -43,6 +48,7 @@ jsonpickle==2.0.0
 jsonschema==3.2.0
 kombu==4.6.7
 lazy-object-proxy==1.6.0
+Markdown==3.3.4
 MarkupSafe==1.1.1
 mccabe==0.6.1
 -e git+https://github.com/metagov/gateway.git@master#egg=metagov&subdirectory=metagov
@@ -53,6 +59,7 @@ parso==0.5.2
 pathspec==0.8.1
 pexpect==4.7.0
 pickleshare==0.7.5
+platformdirs==2.4.0
 prompt-toolkit==3.0.2
 psycopg2-binary==2.8.6
 ptyprocess==0.6.0
@@ -61,21 +68,22 @@ pycparser==2.21
 pycryptodome==3.10.1
 Pygments==2.5.2
 PyJWT==2.3.0
-PyNaCl==1.4.0
 pylint==2.13.9
+PyNaCl==1.4.0
 pyparsing==2.4.7
 pyrsistent==0.18.0
 python-crontab==2.4.0
 python-dateutil==2.8.1
 pytz==2019.3
+PyYAML==6.0.1
 regex==2021.3.17
 requests==2.23.0
 RestrictedPython==5.2
 sentry-sdk==1.9.0
 six==1.15.0
 snowballstemmer==2.1.0
-Sphinx==3.5.4
-sphinx-rtd-theme==0.5.2
+Sphinx==4.1.0
+sphinx-immaterial==0.4.1
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3
@@ -84,6 +92,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 sqlparse==0.3.0
 toml==0.10.2
+tomli==1.2.3
 traitlets==4.3.3
 typed-ast==1.5.5
 typing-extensions==3.10.0.2
@@ -96,6 +105,3 @@ wrapt==1.12.1
 zipp==2.0.1
 zope.event==4.5.0
 zope.interface==5.1.2
-
-django-pattern-library
-djangorestframework


### PR DESCRIPTION
This is a follow up on #581 which fixes some version conflicts caused by installing sphinx immaterial. It removes the sphinx rtd theme, since it is no longer used, and also upgrades the sphinx version so that it is compatible with sphinx immaterial.

Closes https://github.com/policykit/policykit/issues/674