### PR TITLE
Add django debug toolbar

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - DJANGO_SECRET_KEY=supersecretkey
       - SERVER_URL=https://${DOMAIN}
       - ALLOWED_HOSTS=web,.localhost,127.0.0.1,[::1],${DOMAIN}
+      - DJANGO_DEBUG_TOOLBAR=True
     depends_on:
       - rabbit
       - postgres

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -31,6 +31,7 @@ env = environ.Env(
     DJANGO_SECRET_KEY=(str, 'kg=&9zrc5@rern2=&+6yvh8ip0u7$f=k_zax**bwsur_z7qy+-'),
     SENTRY_SERVER_DSN=(str, None),
     SENTRY_CLIENT_SCRIPT=(str, None),
+    DJANGO_DEBUG_TOOLBAR=(bool, False),
 )
 environ.Env.read_env()
 
@@ -41,6 +42,7 @@ SECRET_KEY = env("DJANGO_SECRET_KEY")
 SENTRY_SERVER_DSN = env("SENTRY_SERVER_DSN")
 SENTRY_CLIENT_SCRIPT = env("SENTRY_CLIENT_SCRIPT")
 LOGIN_URL = "/login"
+DEBUG_TOOLBAR = env("DJANGO_DEBUG_TOOLBAR")
 
 if SENTRY_SERVER_DSN:
     import sentry_sdk
@@ -325,3 +327,11 @@ PATTERN_LIBRARY = {
     # BASE_TEMPLATE_NAMES is a "page" and will be rendered as-is without being wrapped.
     "BASE_TEMPLATE_NAMES": ["patterns/base_page.html"],
 }
+
+
+if DEBUG_TOOLBAR:
+    INSTALLED_APPS += ['debug_toolbar']
+    MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
+    DEBUG_TOOLBAR_CONFIG = {
+        'SHOW_TOOLBAR_CALLBACK': lambda request: True,
+    }

--- a/policykit/policykit/urls.py
+++ b/policykit/policykit/urls.py
@@ -98,3 +98,6 @@ if apps.is_installed("pattern_library"):
     urlpatterns += [
         path("pattern-library/", include("pattern_library.urls")),
     ]
+
+if settings.DEBUG_TOOLBAR:
+    urlpatterns.append(path('__debug__/', include('debug_toolbar.urls')))

--- a/policykit/requirements.txt
+++ b/policykit/requirements.txt
@@ -21,6 +21,7 @@ Django==3.2.2
 django-activity-stream==0.10.0
 django-celery-beat==2.2.0
 django-celery-results==2.0.1
+django-debug-toolbar==3.2.4
 django-environ==0.4.5
 django-extensions==3.1.3
 django-filter==2.4.0


### PR DESCRIPTION
This adds the ability to run the app with a debug toolbar enabled. It is disabled by default, and only enabled currently in docker compose for development.

It can be enabled with an env variable, so if did want to enable it temporarily in production for debugging we could do that.

![Screenshot 2024-10-22 at 3 18 15 PM](https://github.com/user-attachments/assets/6a09f4f7-8b93-4b20-8c4f-9c3bc27466f0)

I wanted to add this to more easily debug what template was rendering what page.