### PR TITLE
Debugging Long REST API Support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - ALLOWED_HOSTS=web,.localhost,127.0.0.1,[::1],${DOMAIN}
       - DJANGO_DEBUG_TOOLBAR=True
       - DJANGO_VITE_DEV_MODE=${DJANGO_VITE_DEV_MODE:-True}
+      - DJANGO_SILK=True
     depends_on:
       - rabbit
       - postgres

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -695,3 +695,19 @@ If you're making changes to the `Metagov Gateway <https://docs.metagov.org/>`_ a
      .. code-block:: bash
 
         pip install -e /path/to/gateway/repo/metagov
+
+
+Profiling
+---------
+
+If you are trying to develop PolicyKit and notice that a certain view is slow, we have integrated two extensions to help
+with profiling.
+
+If the view is a Django HTML view, then you can use `Django Debug Toolbar <https://github.com/django-commons/django-debug-toolbar>`_
+to inspect the SQL queries performed. To enable it set the ``DJANGO_DEBUG_TOOLBAR`` env variable to ``True`` (the default
+when developing with Docker).
+
+If the view is REST API, then you can use `Django Silk <https://github.com/jazzband/django-silk>`_. To enable it
+set ``DJANGO_SILK`` to ``True`` (again the default in Docker) and load the API. It will then be recorded in the database
+and you can see the results by accessing the ``/silk/`` endpoint. If you would like to generate a profile for the view,
+`decorate it with ``@silk.profiling.profiler.silk_profile`` <https://github.com/jazzband/django-silk?tab=readme-ov-file#decorator>`_.

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -116,7 +116,20 @@ You can also deploy PolicyKit using Docker.
         env DJANGO_VITE_DEV_MODE=False docker compose run --rm web python manage.py collectstatic
         env DJANGO_VITE_DEV_MODE=False docker compose up web
 
+If you would like to save the DB:
 
+.. code-block:: shell
+
+        docker compose run --rm postgres env PGPASSWORD=password pg_dump -h postgres -Fc -U user policykit > local_db
+
+And to restore it:
+
+.. code-block:: shell
+
+        docker compose run -T --rm postgres env PGPASSWORD=password pg_restore --clean --create --exit-on-error --no-privileges --no-owner -h postgres -U user --verbose -d postgres  < db_dump
+
+If you have restored a database from a production server and want to pretend you are logged in as a user for testing, you can set the ``FORCE_SLACK_LOGIN`` variable in ``.env`` to the full name of a user
+to force that user to always be logged in.
 
 Running PolicyKit on a Server
 -----------------------------

--- a/policykit/.gitignore
+++ b/policykit/.gitignore
@@ -8,4 +8,3 @@ env
 .vscode
 *.log
 policy_backups
-silky_profiles

--- a/policykit/.gitignore
+++ b/policykit/.gitignore
@@ -8,3 +8,4 @@ env
 .vscode
 *.log
 policy_backups
+silky_profiles

--- a/policykit/Dockerfile
+++ b/policykit/Dockerfile
@@ -1,6 +1,11 @@
 # Python 3.10 is the latest version supported by Django 3.2
 FROM python:3.10
 
+# RUN apt-get update \
+#   && apt-get install -yq --no-install-recommends libfuse-dev nano fuse vim git graphviz \
+#   && apt-get clean \
+#   && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app/policykit
 
 COPY requirements.txt .

--- a/policykit/policyengine/api_views.py
+++ b/policykit/policyengine/api_views.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from rest_framework.exceptions import NotFound 
 from django.contrib.auth import get_user
 from django.db import transaction
+from silk.profiling.profiler import silk_profile
 from policyengine.serializers import MemberSummarySerializer, PutMembersRequestSerializer, CommunityDashboardSerializer
 
 @api_view(['GET', 'PUT'])
@@ -24,10 +25,11 @@ def members(request):
         put_members(user, **req.validated_data)
         return Response({}, status=200)
 
-    raise NotImplemented
+    raise NotImplementedError
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
+@silk_profile()
 def dashboard(request):
     user = get_user(request)
     return Response(CommunityDashboardSerializer(user.community.community).data)

--- a/policykit/policykit/middleware.py
+++ b/policykit/policykit/middleware.py
@@ -1,0 +1,23 @@
+
+##
+# Set the `FORCE_SLACK_LOGIN=<readable name>` env variable to force login as a specific user, without having to authenticate.
+# Helpful for development.
+##
+
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth import login
+from django.utils.deprecation import MiddlewareMixin
+
+from integrations.slack.models import SlackUser
+
+User = get_user_model()
+
+class ForceLoginMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        if settings.FORCE_SLACK_LOGIN:
+            user = SlackUser.objects.get(readable_name=settings.FORCE_SLACK_LOGIN)
+            user.backend = 'integrations.slack.auth_backends.SlackBackend'
+            login(request, user)
+

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 
 import os
 import environ
+import tempfile
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -360,9 +361,10 @@ STATICFILES_DIRS = [
 
 SILKY_PYTHON_PROFILER = True
 SILKY_PYTHON_PROFILER_BINARY = True
-SILKY_PYTHON_PROFILER_RESULT_PATH = os.path.join(BASE_DIR, './silky_profiles/')
-if not os.path.exists(SILKY_PYTHON_PROFILER_RESULT_PATH):
-    os.mkdir(SILKY_PYTHON_PROFILER_RESULT_PATH)
+
+# keep reference so not removed
+_tmp_dir = tempfile.TemporaryDirectory("policykit_silky_profiles")
+SILKY_PYTHON_PROFILER_RESULT_PATH = _tmp_dir.name
 
 # Only enable django silk conditionally for debugging. Turns on profiling and records all REST requests
 # for profiling

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -33,6 +33,7 @@ env = environ.Env(
     SENTRY_CLIENT_SCRIPT=(str, None),
     DJANGO_DEBUG_TOOLBAR=(bool, False),
     DJANGO_VITE_DEV_MODE=(bool, False),
+    DJANGO_SILK=(bool, False),
 )
 environ.Env.read_env()
 
@@ -45,6 +46,7 @@ SENTRY_CLIENT_SCRIPT = env("SENTRY_CLIENT_SCRIPT")
 LOGIN_URL = "/login"
 DEBUG_TOOLBAR = env("DJANGO_DEBUG_TOOLBAR")
 DJANGO_VITE_DEV_MODE = env("DJANGO_VITE_DEV_MODE")
+DJANGO_SILK = env("DJANGO_SILK")
 
 if SENTRY_SERVER_DSN:
     import sentry_sdk
@@ -95,7 +97,8 @@ INSTALLED_APPS = [
     'policybuilding_apps',
     'pattern_library',
     "rest_framework",
-    "django_vite"
+    "django_vite",
+    "silk"
 ] + INTEGRATIONS
 
 SITE_ID = 1
@@ -354,3 +357,14 @@ DJANGO_VITE = {
 STATICFILES_DIRS = [
     ('bundler', os.path.join(BASE_DIR, '../frontend/assets')),
 ]
+
+SILKY_PYTHON_PROFILER = True
+SILKY_PYTHON_PROFILER_BINARY = True
+SILKY_PYTHON_PROFILER_RESULT_PATH = os.path.join(BASE_DIR, './silky_profiles/')
+if not os.path.exists(SILKY_PYTHON_PROFILER_RESULT_PATH):
+    os.mkdir(SILKY_PYTHON_PROFILER_RESULT_PATH)
+
+# Only enable django silk conditionally for debugging. Turns on profiling and records all REST requests
+# for profiling
+if DJANGO_SILK:
+    MIDDLEWARE.insert(0, 'silk.middleware.SilkyMiddleware')

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -35,6 +35,7 @@ env = environ.Env(
     DJANGO_DEBUG_TOOLBAR=(bool, False),
     DJANGO_VITE_DEV_MODE=(bool, False),
     DJANGO_SILK=(bool, False),
+    FORCE_SLACK_LOGIN=(str, None),
 )
 environ.Env.read_env()
 
@@ -48,6 +49,7 @@ LOGIN_URL = "/login"
 DEBUG_TOOLBAR = env("DJANGO_DEBUG_TOOLBAR")
 DJANGO_VITE_DEV_MODE = env("DJANGO_VITE_DEV_MODE")
 DJANGO_SILK = env("DJANGO_SILK")
+FORCE_SLACK_LOGIN = env("FORCE_SLACK_LOGIN")
 
 if SENTRY_SERVER_DSN:
     import sentry_sdk
@@ -153,6 +155,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'policykit.middleware.ForceLoginMiddleware',
 ]
 
 ROOT_URLCONF = 'policykit.urls'
@@ -370,3 +373,4 @@ SILKY_PYTHON_PROFILER_RESULT_PATH = _tmp_dir.name
 # for profiling
 if DJANGO_SILK:
     MIDDLEWARE.insert(0, 'silk.middleware.SilkyMiddleware')
+

--- a/policykit/policykit/urls.py
+++ b/policykit/policykit/urls.py
@@ -101,3 +101,7 @@ if apps.is_installed("pattern_library"):
 
 if settings.DEBUG_TOOLBAR:
     urlpatterns.append(path('__debug__/', include('debug_toolbar.urls')))
+
+
+if settings.DJANGO_SILK:
+    urlpatterns += [path('silk/', include('silk.urls', namespace='silk'))]

--- a/policykit/requirements.in
+++ b/policykit/requirements.in
@@ -13,6 +13,7 @@ django-jet
 django-pattern-library
 django-polymorphic
 django-schema-graph
+django-silk
 django-tables2
 django-vite
 djangorestframework

--- a/policykit/requirements.txt
+++ b/policykit/requirements.txt
@@ -6,6 +6,7 @@ asgiref==3.8.1
 astroid==3.3.5
 asttokens==2.4.1
 attrs==24.2.0
+autopep8==2.3.1
 babel==2.16.0
 billiard==4.2.1
 cattrs==24.1.2
@@ -32,6 +33,7 @@ django-jet==1.0.8
 django-pattern-library==1.2.0
 django-polymorphic==3.1.0
 django-schema-graph==3.1.0
+django-silk==5.2.0
 django-tables2==2.7.0
 django-timezone-field==7.0
 django-vite==3.0.5
@@ -39,6 +41,7 @@ djangorestframework==3.15.1
 docutils==0.21.2
 exceptiongroup==1.2.2
 executing==2.1.0
+gprof2dot==2024.6.6
 idna==3.10
 imagesize==1.4.1
 ipython==8.29.0
@@ -64,6 +67,7 @@ prompt_toolkit==3.0.48
 psycopg2-binary==2.9.10
 ptyprocess==0.7.0
 pure_eval==0.2.3
+pycodestyle==2.12.1
 pycryptodome==3.21.0
 pydantic==2.9.2
 pydantic-extra-types==2.10.0


### PR DESCRIPTION
This PR adds a few new features that I am using to help debug the long request time for the dashboard in production.

1. It adds the ability enable django-silk (https://github.com/jazzband/django-silk) which allows you to record rest API calls with timing and SQL information, to be able to analyze them
2. It adds documentation for loading/saving the DB in Docker, to be able to load the production DB locally.
3. It adds a special middleware to allow you to fake being any slack user, so that you can load a production DB locally, and see what the dashboard looks like as a user, without having to first authenticate (which would be hard, since the slack is linked to the other domain and instance).