### PR TITLE
Fix slow loading on homepage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - DATABASE_URL=postgres://user:password@postgres:5432/policykit
       - DJANGO_SECRET_KEY=supersecretkey
       - SERVER_URL=https://${DOMAIN}
-      - ALLOWED_HOSTS=web,.localhost,127.0.0.1,[::1],${DOMAIN}
+      - ALLOWED_HOSTS=*
       - DJANGO_DEBUG_TOOLBAR=True
       - DJANGO_VITE_DEV_MODE=${DJANGO_VITE_DEV_MODE:-True}
       - DJANGO_SILK=True

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -94,9 +94,9 @@ You can also deploy PolicyKit using Docker.
 
 .. code-block:: shell
 
-	docker compose run --rm web python3 manage.py makemigrations
-        docker compose run --rm web python3 manage.py migrate
-        docker compose run --rm web python3 manage.py
+	docker compose run --rm web python manage.py makemigrations
+        docker compose run --rm web python manage.py migrate
+        docker compose run --rm web python manage.py collectstatic
 
 5. Finally, to run PolicyKit and all its services run:
 

--- a/policykit/policyengine/management/commands/dashboard_api.py
+++ b/policykit/policyengine/management/commands/dashboard_api.py
@@ -1,0 +1,36 @@
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+from django.db.models import Prefetch
+
+from constitution.models import *
+from policyengine.models import *
+from integrations.slack.models import SlackUser
+from policyengine.serializers import *
+
+class Command(BaseCommand):
+    help = 'Prints the CommunityDashboardSerializer data for a given slack user and logs the number of queries'
+    def add_arguments(self, parser):
+        parser.add_argument('name', type=str, help='Readbale name of the slack user')
+
+    def handle(self, *args, **kwargs):
+        self.stderr.write(self.style.NOTICE(f"Lookin up user: {kwargs['name']}"))
+        user = SlackUser.objects.get(readable_name=kwargs['name'])
+        self.stderr.write(self.style.NOTICE("Lookin up community"))
+        # try prefetching to reduce number of queries
+        community = Community.objects.prefetch_related(
+            Prefetch("communityplatform_set", ConstitutionCommunity.objects.all(),),
+            "communityrole_set__user_set",
+            # "policy_set__proposal_set__governance_process",
+            # Prefetch("policy_set", Policy.objects.prefetch_related('proposal_set')),
+        ).get(communityplatform__communityuser__pk=user.pk)
+
+        self.stderr.write(self.style.NOTICE("Getting serializer"))
+        data = CommunityDashboardSerializer(community)
+        self.stderr.write(self.style.NOTICE("Getting data"))
+        data = data.data
+        self.stderr.write(self.style.NOTICE("Returning response"))
+        self.stderr.write(self.style.NOTICE(f"Number of Queries: {len(connection.queries)}"))
+        self.stdout.write(str(data))
+
+

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -82,7 +82,11 @@ class Community(models.Model):
         """
         Returns a QuerySet of all proposals in the community.
         """
-        return Proposal.objects.filter(policy__community=self)
+        return Proposal.objects.select_related(
+            "governance_process",
+            "action__initiator",
+            "policy"
+        ).filter(policy__community=self)
 
     def get_platform_communities(self):
         constitution_community = self.constitution_community

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -43,7 +43,7 @@ class Community(models.Model):
         """
         Returns a QuerySet of all roles in the community.
         """
-        return CommunityRole.objects.filter(community=self)
+        return self.communityrole_set.all()
 
     def get_policies(self, is_active=True):
         return Policy.objects.filter(community=self, is_active=is_active).order_by('-modified_at')
@@ -70,12 +70,12 @@ class Community(models.Model):
         """
         Returns a QuerySet of all documents in the community.
         """
-        return CommunityDoc.objects.filter(community=self, is_active=is_active)
+        return self.communitydoc_set.filter(is_active=is_active)
 
     @property
     def constitution_community(self):
         from constitution.models import ConstitutionCommunity
-        return ConstitutionCommunity.objects.filter(community=self).first()
+        return self.communityplatform_set.instance_of(ConstitutionCommunity).first()
 
     @property
     def proposals(self):


### PR DESCRIPTION
This PR fixes the slow loading on the homepage. It now takes only a few seconds to load the API locally, instead of previously it would take minutes, if it finished at all.

The main fix was using `selected_related` to prefetch some proposal data, otherwise an exponential number of queries would be run.

To help debug this issue, I created a custom management command that runs the API response to produce the dashboard and logs how many queries were executed.