### PR TITLE
Go through all pending proposals even if one fails

### DIFF
--- a/policykit/policyengine/tasks.py
+++ b/policykit/policyengine/tasks.py
@@ -21,7 +21,11 @@ def evaluate_pending_proposals():
     #logger.debug("Running evaluate_pending_proposals:" + str(len(pending_proposals)))
 
     for proposal in pending_proposals:
-        community_name = proposal.action.community.community_name
+        try:
+            community_name = proposal.action.community.community_name
+        except Exception as e:
+            logger.error(f"Error getting community name for proposal {proposal}: {repr(e)} {e}")
+            continue
         logger.debug(f"{community_name} - Evaluating proposal '{proposal}'")
         try:
             engine.evaluate_proposal(proposal)


### PR DESCRIPTION
This PR fixes a bug where if one proposal would fail to get a community name then then loop would stop running. Instead, we can just log the error and keep going.

I am not sure why this community name fails, but I noticed it was happening frequently in production.