### PR TITLE
Adds Proposals to the main dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ postgres_data
 celerybeat.pid
 celerybeat-schedule
 log
+models.svg
+models.dot

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -724,3 +724,16 @@ If the view is REST API, then you can use `Django Silk <https://github.com/jazzb
 set ``DJANGO_SILK`` to ``True`` (again the default in Docker) and load the API. It will then be recorded in the database
 and you can see the results by accessing the ``/silk/`` endpoint. If you would like to generate a profile for the view,
 `decorate it with ``@silk.profiling.profiler.silk_profile`` <https://github.com/jazzband/django-silk?tab=readme-ov-file#decorator>`_.
+
+
+Database Schema
+---------------
+
+You can create a visual representation of the database schema by running the following command:
+
+
+.. code-block:: shell
+
+        docker compose run --rm web python manage.py graph_models -a -o ../models.dot
+        dot -Tsvg models.dot > models.svg
+        open models.svg

--- a/frontend/src/dashboard.tsx
+++ b/frontend/src/dashboard.tsx
@@ -263,9 +263,42 @@ export function MetaGovernance() {
   );
 }
 
+export function Proposals() {
+  const data = useData();
+  let proposalsElement;
+  if (!data) {
+    proposalsElement = (
+      <div className="flex flex-col items-center justify-center gap-4 h-32">
+        <p className="text-grey-dark">Loading...</p>
+      </div>
+    );
+  } else {
+    proposalsElement = (
+      <ol>
+        {data.proposals.map((proposal) => (
+          <li key={proposal.id} className="py-2">
+            <p className="text-grey-darkest">
+              <span className="text-grey-dark">{proposal.initiator.readable_name}</span> {proposal.status} a {" "}
+              <span className="text-grey-dark">{proposal.policy.name}</span> policy
+            </p>
+            <p className="text-grey-light">{new Date(proposal.proposal_time).toLocaleString()}</p>
+          </li>
+        ))}
+      </ol>
+    );
+  }
+  return (
+    <div>
+      <h3 className="h5">Proposals</h3>
+      {proposalsElement}
+    </div>
+  );
+}
+
 export function Dashboard() {
   const data = useData();
   return (
+    <>
     <div className="lg:p-6 lg:col-span-7">
       <Welcome />
       <Guidelines />
@@ -280,6 +313,10 @@ export function Dashboard() {
       />
       <MetaGovernance />
     </div>
+    <div className="lg:p-6 lg:col-span-3 border-l border-background-focus">
+      <Proposals />
+    </div>
+    </>
   );
 }
 

--- a/policykit/constitution/models.py
+++ b/policykit/constitution/models.py
@@ -2,7 +2,6 @@ import logging
 
 from django.contrib.auth.models import Permission
 from django.db import models
-from django.core.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -114,6 +114,10 @@ class Community(models.Model):
 
         super(Community, self).save(*args, **kwargs)
 
+    def get_governable_actions(self):
+        # max get 10
+        return self.constitution_community.get_governable_actions()[:20]
+
 class CommunityPlatform(PolymorphicModel):
     """A CommunityPlatform represents a group of users on a single platform."""
 
@@ -151,6 +155,12 @@ class CommunityPlatform(PolymorphicModel):
         The users who should be notified.
         """
         pass
+
+    def get_governable_actions(self):
+        """
+        Returns a QuerySet of all governable actions in the community.
+        """
+        return GovernableAction.objects.filter(community=self)
 
     def get_roles(self):
         """

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -86,7 +86,8 @@ class Community(models.Model):
             "governance_process",
             "action__initiator",
             "policy"
-        ).filter(policy__community=self)
+        ).filter(policy__community=self).order_by('-proposal_time')[:50]
+
 
     def get_platform_communities(self):
         constitution_community = self.constitution_community

--- a/policykit/policyengine/serializers.py
+++ b/policykit/policyengine/serializers.py
@@ -54,6 +54,17 @@ class CommunityDocSerializer(serializers.Serializer):
     name = serializers.CharField()
     text = serializers.CharField()
 
+class CommunityUserSummarySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    readable_name = serializers.CharField()
+
+
+class ActionSummarySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    initiator = CommunityUserSummarySerializer()
+    str = serializers.CharField(source='__str__')
+
+
 class CommunityDashboardSerializer(serializers.Serializer):
     roles = DashboardRoleSummarySerializer(many=True, source='get_roles')
     community_docs = CommunityDocSerializer(source='get_documents', many=True)
@@ -62,3 +73,5 @@ class CommunityDashboardSerializer(serializers.Serializer):
     trigger_policies = PolicySummarySerializer(many=True, source='get_trigger_policies')
     proposals = ProposalSummarySerializer(many=True)
     name = serializers.CharField(source="community_name")
+    # Don't include governable actions for now, instead we use proposals
+    # governable_actions = ActionSummarySerializer(many=True, source="get_governable_actions")


### PR DESCRIPTION
This PR adds a right column to the dashboard with "proposals" that have had actions taken on them:

<img width="1792" alt="Screenshot 2025-02-18 at 11 56 28 AM" src="https://github.com/user-attachments/assets/2f52d97f-2ba1-4220-9736-5fc802b6ac9e" />


It is based roughly on the "Governance History" section on the mockups:

<img width="1380" alt="Screenshot 2025-02-18 at 12 06 23 PM" src="https://github.com/user-attachments/assets/819c7037-ed2f-4db0-8615-d12de154f737" />


I displayed "proposals" instead of "governable actions", because they were already serialized (so thinking that whoever worked on it last intended them to be used) and because "governable actions" dont seem to have a date/time associated with them AFAIK. So I wasn't sure how to display them.

I did set up serialization for them and could add them if we wish! That would I believe get us closer to the semantics of the figma.