### PR TITLE
Change proposals list to show action type

### DIFF
--- a/frontend/src/dashboard.tsx
+++ b/frontend/src/dashboard.tsx
@@ -19,6 +19,7 @@ type PolicySummary = {
 type ActionSummary = {
   id: number;
   action_type: string;
+  description: string;
 };
 
 type InitiatorSummary = {
@@ -256,8 +257,9 @@ export function Proposals() {
         {data.proposals.map((proposal) => (
           <li key={proposal.id} className="py-2">
             <p className="text-grey-darkest">
-              <span className="text-grey-dark">{proposal.initiator.readable_name}</span> {proposal.status} a {" "}
-              <span className="text-grey-dark">{proposal.policy.name}</span> policy
+            <span className="text-grey-dark">{proposal.action.description}</span> action {" "}
+            {proposal.status} from <span className="text-grey-dark">{proposal.policy.name}</span> policy
+            {proposal.initiator.readable_name ? (<> by <span className="text-grey-dark">{proposal.initiator.readable_name}</span></>) : null}
             </p>
             <p className="text-grey-light">{new Date(proposal.proposal_time).toLocaleString()}</p>
           </li>

--- a/frontend/src/dashboard.tsx
+++ b/frontend/src/dashboard.tsx
@@ -251,20 +251,27 @@ export function ProposalsList({proposals}: {proposals: ProposalSummary[] | undef
       </div>
     );
   }
+  if (proposals.length === 0) {
     return (
-      <ol>
-        {proposals.map((proposal) => (
-          <li key={proposal.id} className="py-2">
-            <p className="text-grey-darkest">
-            <span className="text-grey-dark">{proposal.action.description}</span> action {" "}
-            {proposal.status} from <span className="text-grey-dark">{proposal.policy.name}</span> policy
-            {proposal.initiator.readable_name ? (<> by <span className="text-grey-dark">{proposal.initiator.readable_name}</span></>) : null}
-            </p>
-            <p className="text-grey-light">{new Date(proposal.proposal_time).toLocaleString()}</p>
-          </li>
-        ))}
-      </ol>
-    )
+      <div className="flex flex-col items-center justify-center gap-4 h-32">
+        <p className="text-grey-dark">No Proposals</p>
+      </div>
+    );
+  }
+  return (
+    <ol>
+      {proposals.map((proposal) => (
+        <li key={proposal.id} className="py-2">
+          <p className="text-grey-darkest">
+          <span className="text-grey-dark">{proposal.action.description}</span> action {" "}
+          {proposal.status} from <span className="text-grey-dark">{proposal.policy.name}</span> policy
+          {proposal.initiator.readable_name ? (<> by <span className="text-grey-dark">{proposal.initiator.readable_name}</span></>) : null}
+          </p>
+          <p className="text-grey-light">{new Date(proposal.proposal_time).toLocaleString()}</p>
+        </li>
+      ))}
+    </ol>
+  )
   
 }
 

--- a/frontend/src/dashboard.tsx
+++ b/frontend/src/dashboard.tsx
@@ -56,7 +56,8 @@ type CommunityDashboard = {
   trigger_policies: PolicySummary[];
   platform_policies: PolicySummary[];
   constitution_policies: PolicySummary[];
-  proposals: ProposalSummary[];
+  pending_proposals: ProposalSummary[];
+  completed_proposals: ProposalSummary[];
   name: string;
 };
 
@@ -242,19 +243,17 @@ export function MetaGovernance() {
   );
 }
 
-export function Proposals() {
-  const data = useDashboardData();
-  let proposalsElement;
-  if (!data) {
-    proposalsElement = (
+export function ProposalsList({proposals}: {proposals: ProposalSummary[] | undefined}) {
+  if (!proposals) {
+    return (
       <div className="flex flex-col items-center justify-center gap-4 h-32">
         <p className="text-grey-dark">Loading...</p>
       </div>
     );
-  } else {
-    proposalsElement = (
+  }
+    return (
       <ol>
-        {data.proposals.map((proposal) => (
+        {proposals.map((proposal) => (
           <li key={proposal.id} className="py-2">
             <p className="text-grey-darkest">
             <span className="text-grey-dark">{proposal.action.description}</span> action {" "}
@@ -265,12 +264,18 @@ export function Proposals() {
           </li>
         ))}
       </ol>
-    );
-  }
+    )
+  
+}
+
+export function Proposals() {
+  const data = useDashboardData();
   return (
     <div>
-      <h3 className="h5">Proposals</h3>
-      {proposalsElement}
+      <h3 className="h5">Pending Proposals</h3>
+      <ProposalsList proposals={data?.pending_proposals} />
+      <h3 className="h5">Completed Proposals</h3>
+      <ProposalsList proposals={data?.completed_proposals} />
     </div>
   );
 }

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -80,11 +80,15 @@ class Community(models.Model):
 
     @property
     def completed_proposals(self):
-        return self.proposals.filter(~Q(governance_process__status="pending"))[:50]
+        return self.proposals.filter(
+            ~Q(status=Proposal.PROPOSED)
+        )[:50]
     
     @property
     def pending_proposals(self):
-        return self.proposals.filter(governance_process__status="pending")[:50]
+        return self.proposals.filter((
+            Q(status=Proposal.PROPOSED)
+        ))[:50]
 
     @property
     def proposals(self):
@@ -709,7 +713,10 @@ class BaseAction(PolymorphicModel):
     def description(self):
         # this causes one query per call but we cannot use selected_related with polymorphic models
         # https://github.com/jazzband/django-polymorphic/issues/198
-        upcast = self.get_real_instance()
+        try:
+            upcast = self.get_real_instance()
+        except AttributeError:
+            upcast = self
         return getattr(upcast, 'ACTION_NAME', str(upcast))
 
     @property

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -704,7 +704,7 @@ class BaseAction(PolymorphicModel):
     """Datastore for persisting any additional data related to the proposal."""
 
     def __str__(self):
-        return f"{self._meta.verbose_name.title()} ({self.pk})"
+        return self._meta.verbose_name.title()
 
     def description(self):
         # this causes one query per call but we cannot use selected_related with polymorphic models
@@ -852,7 +852,7 @@ class ExecutedActionTriggerAction(TriggerAction):
         )
 
     def __str__(self):
-        return f"Trigger: {self.action._meta.verbose_name.title()} ({self.pk})"
+        return f"Trigger: {self.action._meta.verbose_name.title()}"
 
 
 class WebhookTriggerAction(TriggerAction):
@@ -864,7 +864,7 @@ class WebhookTriggerAction(TriggerAction):
     #add platform_community_platform_id
 
     def __str__(self):
-        return f"Trigger: {self.event_type} ({self.pk})"
+        return f"Trigger: {self.event_type}"
 
 class PlatformPolicyManager(models.Manager):
     def get_queryset(self):

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -701,6 +701,12 @@ class BaseAction(PolymorphicModel):
     def __str__(self):
         return f"{self._meta.verbose_name.title()} ({self.pk})"
 
+    def description(self):
+        # this causes one query per call but we cannot use selected_related with polymorphic models
+        # https://github.com/jazzband/django-polymorphic/issues/198
+        upcast = self.get_real_instance()
+        return getattr(upcast, 'ACTION_NAME', str(upcast))
+
     @property
     def action_type(self):
         """The type of action (such as 'slackpostmessage' or 'policykitaddcommunitydoc')."""

--- a/policykit/policyengine/serializers.py
+++ b/policykit/policyengine/serializers.py
@@ -77,7 +77,8 @@ class CommunityDashboardSerializer(serializers.Serializer):
     platform_policies = PolicySummarySerializer(many=True, source='get_platform_policies')
     constitution_policies = PolicySummarySerializer(many=True, source='get_constitution_policies')
     trigger_policies = PolicySummarySerializer(many=True, source='get_trigger_policies')
-    proposals = ProposalSummarySerializer(many=True)
+    pending_proposals = ProposalSummarySerializer(many=True)
+    completed_proposals = ProposalSummarySerializer(many=True)
     name = serializers.CharField(source="community_name")
     # Don't include governable actions for now, instead we use proposals
     # governable_actions = ActionSummarySerializer(many=True, source="get_governable_actions")

--- a/policykit/policyengine/serializers.py
+++ b/policykit/policyengine/serializers.py
@@ -40,6 +40,7 @@ class PolicySummarySerializer(serializers.Serializer):
 class ActionSummarySerializer(serializers.Serializer):
     id = serializers.IntegerField()
     action_type = serializers.CharField()
+    description = serializers.CharField()
 
 class InitiatorSummarySerializer(serializers.Serializer):
     id = serializers.IntegerField()


### PR DESCRIPTION
Follow up from #696 to show action type along with each proposal

<img width="425" alt="Screenshot 2025-03-18 at 3 03 52 PM" src="https://github.com/user-attachments/assets/08ee35ad-6941-4834-b65d-322719a8a002" />

<img width="445" alt="Screenshot 2025-03-18 at 3 03 59 PM" src="https://github.com/user-attachments/assets/d3967d21-2722-4e05-a919-75c88fc5dc5e" />


Uses `ACTION_NAME` and falls back on `str` if that is not defined.