### PR TITLE
Remove unused import

### DIFF
--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -2,7 +2,6 @@ import json
 import logging
 from datetime import datetime, timezone
 from operator import is_
-from tkinter import N
 
 from actstream import action as actstream_action
 from django.contrib.auth.models import Group, User, UserManager


### PR DESCRIPTION
Removed unused TKinter import which will raise an exception if not installed on ubuntu.