### PR TITLE
Fix frontend build

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -113,7 +113,6 @@ You can also deploy PolicyKit using Docker.
 .. code-block:: shell
 
         docker compose run --rm frontend yarn build
-        env DJANGO_VITE_DEV_MODE=False docker compose run --rm web python manage.py collectstatic
         env DJANGO_VITE_DEV_MODE=False docker compose up web
 
 If you would like to save the DB:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       input: {
         dashboard: "/src/dashboard.tsx",
         members: "/src/members.tsx",
+        style: "/src/style.css",
       },
     },
   },


### PR DESCRIPTION
Fixes frontend build error introduced in most recent PR. We have to build the style file separately since we want to include it now in all new dashboard pages even if they dont use the frontend since it has the most recent tailwind